### PR TITLE
最低対応 NodeJS バージョンを >=18 に変更

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 ## Requirement
 
 ```
-"node": ">=16"
+"node": ">=18"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Address Base Registry Geocoder by Japan Digital Agency
 ## Requirement
 
 ```
-"node": ">=16"
+"node": ">=18"
 ```
 
 ## Usage

--- a/build/normalizer.js
+++ b/build/normalizer.js
@@ -31,6 +31,9 @@ const node_path_1 = __importDefault(require("node:path"));
 const NJANormalize = __importStar(require("./engine/normalize"));
 const better_sqlite3_1 = __importDefault(require("better-sqlite3"));
 class Normalize {
+    dataDir;
+    sourceId;
+    _db;
     constructor(dataDir, sourceId) {
         this.dataDir = dataDir;
         this.sourceId = sourceId;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "bin": {
     "abr-geocoder": "build/cli.js"
@@ -18,17 +18,17 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^1.0.3",
+    "@tsconfig/node18": "^2.0.1",
     "@types/better-sqlite3": "^7.6.3",
     "@types/byline": "^4.2.33",
     "@types/cli-progress": "^3.11.0",
     "@types/jest": "^29.4.0",
-    "@types/node": "^16",
+    "@types/node": "^18",
     "@types/proj4": "^2.5.2",
     "jest": "^29.4.2",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "./build",                        /* Redirect output structure to the directory. */
     "lib": ["dom"],
@@ -12,8 +12,6 @@
     "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules/**/*",
-    "src/vendor/normalize-japanese-addresses/test/**/*",
-    "src/vendor/normalize-japanese-addresses/*",
+    "node_modules/**/*"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,10 +606,15 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
-"@tsconfig/node16@^1.0.2", "@tsconfig/node16@^1.0.3":
+"@tsconfig/node16@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
+"@tsconfig/node18@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-2.0.1.tgz#2d2e11333ef2b75a4623203daca264e6697d693b"
+  integrity sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==
 
 "@types/babel__core@^7.1.14":
   version "7.20.0"
@@ -704,10 +709,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
   integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
 
-"@types/node@^16":
-  version "16.18.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.13.tgz#c572f8837094c6e3b73918a68674c784f6877fc0"
-  integrity sha512-l0/3XZ153UTlNOnZK8xSNoJlQda9/WnYgiTdcKKPJSZjdjI9MU+A9oMXOesAWLSnqAaaJhj3qfQsU07Dr8OUwg==
+"@types/node@^18":
+  version "18.16.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.18.tgz#85da09bafb66d4bc14f7c899185336d0c1736390"
+  integrity sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==
 
 "@types/prettier@^2.1.5":
   version "2.7.2"
@@ -2498,10 +2503,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 undici@^5.18.0:
   version "5.20.0"


### PR DESCRIPTION
この変更に伴い、 `@tsconfig/node16` の TypeScript 設定を 18 にアップグレードしました。合わせて、 TypeScript 5.1 にもアップグレードしました。