### PR TITLE
GitHub Actions によるリリース自動化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn run build
+
+      - name: set npm auth token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+
+      - run: npm publish . --access public

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "abr-geocoder",
   "version": "1.0.0",
   "description": "デジタル庁：アドレス・ベース・レジストリを用いたジオコーダー",
+  "author": "Japan Digital Agency (デジタル庁)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/digital-go-jp/abr-geocoder.git"
+  },
+  "bugs": {
+    "url": "https://github.com/digital-go-jp/abr-geocoder/issues"
+  },
+  "homepage": "https://github.com/digital-go-jp/abr-geocoder",
   "main": "index.js",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "デジタル庁：アドレス・ベース・レジストリを用いたジオコーダー",
   "main": "index.js",
   "license": "MIT",
-  "private": true,
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
タグを打つことで、npmjs.com へのパッケージリリースが自動的に行われるよう、GitHub Actions の設定を行いました。
例えば v1.0.0 をリリースする場合、ローカルマシンで

```shell
$ git tag -a v1.0.0 -m "v1.0.0"
$ git push origin v1.0.0
```

のようなコマンドを打つことで、npm に本パッケージをリリースすることができるようになります。

-----

正しく動作させるために、シークレットとして `NPM_AUTH_TOKEN` を登録する必要があります。

1. https://www.npmjs.com にログインした状態で、右上の自分のアイコン → **Access Tokens** と進む
2. **Generate New Token** ボタンを押し、**Granular Access Token** をクリックする
3. 2要素認証のワンタイムパスワードを求められた場合、入力する
4. フォームの内容を埋め、**Generate Token** ボタンを押す
    - **Packages and scopes** は、**Read and write** に設定して下さい
5. トークンが表示されるので、トークンをコピーする
6. GitHub に移り、本リポジトリーの **Settings** → **Secrets and Variables** → **Actions** に進む
7. **New repository secret** ボタンを押し、Name に `NPM_AUTH_TOKEN`、Secret に先程コピーしたトークンを入力の上、**Add secret** ボタンを押す

以上のような手順で、正常に npm パッケージをリリースすることができるようになります。

-----

なお、yarn publish コマンドは、現在お使いの yarn v1 に関しては、あまり技術資料を見つけることができませんでした。そのため、publish コマンドのみ npm を用いて `npm publish . --access public` としています。