### PR TITLE
scoped package になるようパッケージ名を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "abr-geocoder",
+  "name": "@digital-go-jp/abr-geocoder",
   "version": "1.0.0",
   "description": "デジタル庁：アドレス・ベース・レジストリを用いたジオコーダー",
   "main": "index.js",


### PR DESCRIPTION
現状のままパッケージをリリースすると、パッケージ名が `abr-geocoder` となり、`@digital-go-jp/` 以下に置かれなくなります。
本 Pull Request によりパッケージ名が `@digital-go-jp/abr-geocoder` となり、`@digital-go-jp/` 以下に置かれるようになります。