### PR TITLE
コマンド名をabrg に省略する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,20 +43,20 @@ $ npm run build
 ```
 (global install)
 $ npm -g install .
-$ abr-geocoder --version
+$ abrg --version
 ```
 
 または `npx` コマンドを併用する場合
 ```
 (local usage)
-$ npx abr-geocoder --version
+$ npx abrg --version
 ```
 
 ## 使い方
 
 ```
-$ abr-geocoder download # アドレス・ベース・レジストリのデータをダウンロードし、データベース作成を行う
-$ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abr-geocoder normalize -
+$ abrg download # アドレス・ベース・レジストリのデータをダウンロードし、データベース作成を行う
+$ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abrg normalize -
 ```
 
 ### `download`
@@ -64,19 +64,19 @@ $ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾
 サーバーから最新データを取得します。
 
 ```
-$ abr-geocoder download
+$ abrg download
 ```
 
 アドレス・ベース・レジストリの[「全アドレスデータ」](https://catalog.registries.digital.go.jp/rc/dataset/ba000001) を `$HOME/.abr-geocoder` ディレクトリにダウンロードし、SQLiteを使ってデータベースを構築します。
 
-作成済みのデータベースを更新するには、`abr-geocoder download` を実行します。
+作成済みのデータベースを更新するには、`abrg download` を実行します。
 
 ### `update-check`
 
 データのアップデートの有無を確認する。
 
 ```
-$ abr-geocoder update-check
+$ abrg update-check
 ```
 
 最新である場合は戻り値 `0` を返し、正常終了します。
@@ -89,7 +89,7 @@ CKANに新しいデータが存在する場合（ローカルのデータを確�
 アドレスをジオコーディングする。
 
 ```
-$ abr-geocoder normalize [options] <inputFile>
+$ abrg normalize [options] <inputFile>
 ```
 
 `<inputFile>` で指定されたテキストファイルをジオコーディングします。
@@ -105,7 +105,7 @@ $ abr-geocoder normalize [options] <inputFile>
 
 標準入力からデータを渡したい場合は、 '-' を指定することができます。
 ```
-echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abr-geocoder normalize -
+echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abrg normalize -
 ```
 
 
@@ -138,10 +138,10 @@ JSONの出力や、GeoJSONの出力のサンプルは下記「出力結果のフ
 `?` のワイルドカードを利用して曖昧一致させることができます。 `--fuzzy` オプションを利用してください。
 
 ```
-$ echo '東京都千代?区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abr-geocoder normalize --format=ndjson -
+$ echo '東京都千代?区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abrg normalize --format=ndjson -
 {"pref":"東京都","city":"","town":"","other":"千代?区紀尾井町1-3 東京ガーデンテラス紀尾井町 19階、20階","lat":null,"lon":null,"level":1}
 
-$ echo '東京都千代田区紀尾?町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abr-geocoder normalize --fuzzy --format=ndjson -
+$ echo '東京都千代田区紀尾?町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abrg normalize --fuzzy --format=ndjson -
 {"pref":"東京都","city":"千代田区","lg_code":"131016","town":"紀尾井町","town_id":"0056000","other":"東京ガーデンテラス紀尾井町 19階、20階","lat":35.679107172,"lon":139.736394597,"level":8,"addr1":"3","blk":"1","blk_id":"001","addr1_id":"003","addr2":"","addr2_id":""}
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ Then you need to install globally,
 ```
 (global install)
 $ npm -g install .
-$ abr-geocoder --version
+$ abrg --version
 ```
 
 or use with `npx`.
 ```
 (local usage)
-$ npx abr-geocoder --version
+$ npx abrg --version
 ```
 
 ## Usage
 
 ```
-$ abr-geocoder download # Download data from the address base registry and create a database.
-$ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abr-geocoder normalize -
+$ abrg download # Download data from the address base registry and create a database.
+$ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abrg normalize -
 ```
 
 ### `download`
@@ -68,20 +68,20 @@ $ echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾
 Obtains the latest data from server.
 
 ```
-$ abr-geocoder download
+$ abrg download
 ```
 
 Downloads the public data from the address base registry ["全アドレスデータ"](https://catalog.registries.digital.go.jp/rc/dataset/ba000001) into the `$HOME/.abr-geocoder` directory,
 then creates a local database using SQLite.
 
-To update the local database, runs `abr-geocoder download`.
+To update the local database, runs `abrg download`.
 
 ### `update-check`
 
 Checks the new update data.
 
 ```
-$ abr-geocoder update-check
+$ abrg update-check
 ```
 
 Returns `0` if the local database is the latest.
@@ -93,7 +93,7 @@ Returns `1` if new data in CKAN is available. there is no local database, return
 Geocodes Japanese addresses.
 
 ```
-$ abr-geocoder normalize [options] <inputFile>
+$ abrg normalize [options] <inputFile>
 ```
 
 Geocodes from the `<inputFile>`. The input file must have Japanese address each line.
@@ -110,7 +110,7 @@ For example:
 You can also pass the input query through `pipe` command. `-` denotes `stdin`.
 
 ```
-echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abr-geocoder normalize -
+echo "東京都千代田区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階" | abrg normalize -
 ```
 
 #### Available options
@@ -140,10 +140,10 @@ Without the `nd` prefix, the command outputs the results after all processes are
 You can include `?` character for wildcard matching with `--fuzzy` option.
 
 ```
-$ echo '東京都千代?区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abr-geocoder normalize --format=ndjson -
+$ echo '東京都千代?区紀尾井町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abrg normalize --format=ndjson -
 {"pref":"東京都","city":"","town":"","other":"千代?区紀尾井町1-3 東京ガーデンテラス紀尾井町 19階、20階","lat":null,"lon":null,"level":1}
 
-$ echo '東京都千代田区紀尾?町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abr-geocoder normalize --fuzzy --format=ndjson -
+$ echo '東京都千代田区紀尾?町1-3　東京ガーデンテラス紀尾井町 19階、20階' | abrg normalize --fuzzy --format=ndjson -
 {"pref":"東京都","city":"千代田区","lg_code":"131016","town":"紀尾井町","town_id":"0056000","other":"東京ガーデンテラス紀尾井町 19階、20階","lat":35.679107172,"lon":139.736394597,"level":8,"addr1":"3","blk":"1","blk_id":"001","addr1_id":"003","addr2":"","addr2_id":""}
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=18"
   },
   "bin": {
-    "abr-geocoder": "build/cli.js"
+    "abrg": "build/cli.js"
   },
   "scripts": {
     "start": "ts-node src/cli.ts",


### PR DESCRIPTION
コマンド名 `abr-geocoder` が長いので、`abrg` に省略する (issue #10)