### PR TITLE
Fix: "other"のスペースが削除されてしまうケースがある

### DIFF
--- a/src/engine/normalize.ts
+++ b/src/engine/normalize.ts
@@ -193,7 +193,7 @@ async function normalizeResidentialPart(
   const match = inputOther.match(/^([1-9][0-9]*)(?:-([1-9][0-9]*))?(?:-([1-9][0-9]*))?/)
   if (match) {
     const matchedString = match[0];
-    const other = inputOther.substring(matchedString.length).trim()
+    const other = inputOther.substring(matchedString.length);
 
     const blk = match[1]
     const addr1 = match[2]
@@ -211,10 +211,10 @@ async function normalizeResidentialPart(
         addr1_id: residentialWithAddr2.addr1_id,
         addr2: addr2 || "",
         addr2_id: residentialWithAddr2.addr2_id,
-        other,
+        other: other.trim(),
         lat: residentialWithAddr2.lat,
         lon: residentialWithAddr2.lon,
-      }
+      };
     }
 
     if (addr2) {
@@ -225,6 +225,7 @@ async function normalizeResidentialPart(
       )
 
       if (residential) {
+        const otherResult = ((addr2 ? `-${addr2}` : '') + other.replace(/\s+/g, " ")).trim();
         return {
           blk,
           blk_id: residential.blk_id,
@@ -232,7 +233,7 @@ async function normalizeResidentialPart(
           addr1_id: residential.addr1_id,
           addr2: "",
           addr2_id: "",
-          other: (addr2 ? `-${addr2}` : '') + other,
+          other: otherResult,
           lat: residential.lat,
           lon: residential.lon,
         }


### PR DESCRIPTION
# 関連するissue

* #17 

## 変更内容

以下コードの`trim()`が原因。
```ts
const other = inputOther.substring(matchedString.length).trim()
```

`normalizeResidentialPart()`の結果を返す部分で`trim()`するように変更

## 備考

テストコードは未チェックなので、用意できていないので、とりあえずスクリーンショットを添付。

![Screenshot 2023-07-10 at 12 25 32 AM](https://github.com/digital-go-jp/abr-geocoder/assets/167831/fa24eb6c-f749-4b88-9ecf-83ed7b92c547)

Note: `abrg`コマンドは`develop`ブランチをベースにしているため。