### PR TITLE
fix: AbrGeocoderStream の UnhandledPromiseRejection を修正しエラー処理を追加

### DIFF
--- a/src/usecases/geocode/__tests__/abr-geocoder-stream.test.ts
+++ b/src/usecases/geocode/__tests__/abr-geocoder-stream.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import { Readable } from 'node:stream';
+import { AbrGeocoder } from '../abr-geocoder';
+import { AbrGeocoderStream } from '../abr-geocoder-stream';
+import { MatchLevel } from '@domain/types/geocode/match-level';
+
+describe('AbrGeocoderStream', () => {
+  test('should handle rejection from geocoder', (done) => {
+    const mockGeocoder = {
+      geocode: jest.fn().mockRejectedValue(new Error('Test Error')),
+      close: jest.fn().mockResolvedValue(undefined),
+    } as unknown as AbrGeocoder;
+
+    const stream = new AbrGeocoderStream({
+      geocoder: mockGeocoder,
+      fuzzy: '?',
+    });
+
+    const input = ['東京都千代田区千代田1-1'];
+    const readable = Readable.from(input);
+
+    readable.pipe(stream);
+
+    let receivedCount = 0;
+    stream.on('data', (data) => {
+      receivedCount++;
+      if (data.match_level.num === MatchLevel.ERROR.num) {
+        done();
+      }
+    });
+
+    stream.on('end', () => {
+      if (receivedCount === 0) {
+        done(new Error('Stream ended without receiving data'));
+      }
+    });
+
+    stream.on('error', (err) => {
+      done(err);
+    });
+  });
+});

--- a/src/usecases/geocode/abr-geocoder-stream.ts
+++ b/src/usecases/geocode/abr-geocoder-stream.ts
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 import { DEFAULT_FUZZY_CHAR } from '@config/constant-values';
+import { MatchLevel } from '@domain/types/geocode/match-level';
 import { SearchTarget } from '@domain/types/search-target';
 import { Duplex } from 'node:stream';
 import { AbrGeocoder } from './abr-geocoder';
@@ -40,7 +41,7 @@ export class AbrGeocoderStream extends Duplex {
   private halfWatermark: number;
 
   constructor(params: {
-    geocoder: AbrGeocoder,
+    geocoder: AbrGeocoder;
     fuzzy: string;
     searchTarget?: SearchTarget;
     highWatermark?: number;
@@ -91,9 +92,9 @@ export class AbrGeocoderStream extends Duplex {
 
   // 前のstreamからデータが渡されてくる
   async _write(
-    input: string, 
+    input: string,
     _: BufferEncoding,
-    callback: (error?: Error | null | undefined) => void,
+    callback: (error?: Error | null | undefined) => void
   ) {
     this.waiter();
 
@@ -102,29 +103,43 @@ export class AbrGeocoderStream extends Duplex {
     // 次のタスクをもらうために、callbackを呼び出す
     callback();
 
-    this.geocoder.geocode({
-      address: input.toString(),
-      searchTarget: this.searchTarget,
-      fuzzy: this.fuzzy,
-      tag: {
-        lineId,
-      },
-    })
+    this.geocoder
+      .geocode({
+        address: input.toString(),
+        searchTarget: this.searchTarget,
+        fuzzy: this.fuzzy,
+        tag: {
+          lineId,
+        },
+      })
       // 処理が成功したら、別スレッドで処理した結果をQueryに変換する
       .then((result: Query) => {
         this.push(result);
         this.nextIdx++;
         this.closer();
         // this.emit(this.kShiftEvent, result);
+      })
+      // エラーが発生した
+      .catch((_error: Error | string) => {
+        const query = Query.create({
+          data: {
+            address: input.toString(),
+            searchTarget: this.searchTarget,
+            fuzzy: this.fuzzy,
+            tag: {
+              lineId,
+            },
+          },
+          taskId: -1,
+        });
+        this.push(
+          query.copy({
+            match_level: MatchLevel.ERROR,
+          })
+        );
+        this.nextIdx++;
+        this.closer();
       });
-    // エラーが発生した
-    // .catch((error: Error | string) => {
-    //   const query = Query.create(input);
-    //   this.emit(this.kShiftEvent, query.copy({
-    //     match_level: MatchLevel.ERROR,
-    //   }));
-    // })
-
   }
 
   // 前のストリームからの書き込みが終了した
@@ -136,5 +151,3 @@ export class AbrGeocoderStream extends Duplex {
     callback();
   }
 }
-
-


### PR DESCRIPTION
Closes #232

## 概要
`AbrGeocoderStream` において `geocoder.geocode` が失敗（reject）した際、エラーが捕捉されずに `UnhandledPromiseRejection` が発生し、プロセスがクラッシュする問題を修正しました。

## 変更内容
- `src/usecases/geocode/abr-geocoder-stream.ts`
    - コメントアウトされていた `.catch` ブロックを復活させ、現在の実装に合わせて修正しました。
    - エラー発生時にはストリームを停止せず、`MatchLevel.ERROR` を設定した `Query` オブジェクトを下流に流すように変更しました。
    - 正常系と同様に `this.nextIdx++` と `this.closer()` を呼び出し、ストリームの状態整合性を維持するようにしました。
- `src/usecases/geocode/__tests__/abr-geocoder-stream.test.ts`
    - 本修正の検証用として、`geocoder` が `reject` した場合の挙動を確認するテストケースを追加しました。
 
## 動作確認
- [x] 新規追加したテストケース (`npm test -- src/usecases/geocode/__tests__/abr-geocoder-stream.test.ts`) が通過することを確認
- [x] 既存のテストへの影響がないこと（エラーハンドリング追加によるリグレッションがないこと）を確認

## 補足
元々コメントアウトされていた実装意図（エラー時も処理を継続し、結果としてエラー情報を返す）を尊重し、型定義やストリーム制御（`push` vs `emit`）を現状のコードベースに合わせて再実装しました。