### PR TITLE
V2.3.0

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,11 @@
 
 - [English version](./README.md)
 
+## 🚨 Version 2.2.1 から Version 2.3.0 へのアップグレード
+
+- **バグ修正**: `abrg download -c <都道府県LGCode>` で `mt_town_pos_pref**.csv`（町字マスター位置参照拡張・都道府県単位）がダウンロードされない問題を修正しました。
+- **重要**: Version 3 のリリースに伴い、Version 2.3.0 は Version 2 系の最終リリースとなります。以降の修正・機能追加は Version 3 で行われ、Version 2 系での対応はありません。
+
 ## 🚨 Version 2.2 から Version 2.2.1 へのアップグレード
 
 - データセットダウンロード用の新しいDCAT形式APIに対応しました。

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 - [日本語版](./README.ja.md)
 
+## 🚨 Upgrade to version 2.3.0 from v2.2.1
+
+- **Bug fix**: `abrg download -c <prefecture LGCode>` no longer skips `mt_town_pos_pref**.csv` (town master position-reference extension at the prefecture level).
+- **Important**: With the upcoming Version 3 release, Version 2.3.0 is the final release of the Version 2 series. Subsequent fixes and feature additions will be made in Version 3, and no further support is planned for the Version 2 series.
+
 ## 🚨 Upgrade to version 2.2.1 from v2.2
 
 - Updated to use the new DCAT format API for downloading datasets.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-go-jp/abr-geocoder",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "デジタル庁：アドレス・ベース・レジストリを用いたジオコーダー",
   "author": "Japan Digital Agency (デジタル庁)",
   "keywords": [
@@ -55,7 +55,7 @@
     "eslint": "^9.11.1",
     "execa-cjs": "^9.1.1",
     "jest": "^29.7.0",
-    "jest-junit": "^16.0.0",
+    "jest-junit": "^17.0.0",
     "rimraf": "^6.0.1",
     "ts-add-js-extension": "^1.6.4",
     "ts-jest": "^29.2.5",
@@ -76,7 +76,7 @@
     "i18next": "^23.15.1",
     "json-stable-stringify": "^1.1.1",
     "lru-cache": "^10.4.3",
-    "node-gyp": "^10.2.0",
+    "node-gyp": "^12.3.0",
     "proj4": "^2.12.1",
     "range-parser": "^1.2.1",
     "string-hash": "^1.1.3",

--- a/src/interface/__mocks__/http-request-adapter.ts
+++ b/src/interface/__mocks__/http-request-adapter.ts
@@ -21,6 +21,10 @@ const PackageListResponse = {
       // 東京都データ (13....)
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_rsdtdsp_rsdt_pos/pref/mt_rsdtdsp_rsdt_pos_pref13.csv.zip" }] },
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_city_pos/pref/mt_city_pos_pref13.csv.zip" }] },
+      // town_pos は pref スコープにしか存在しない (区指定でも pref から取得する必要がある)
+      { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town_pos/pref/mt_town_pos_pref13.csv.zip" }] },
+      // town は city スコープ版で取得するため、pref レベル (mt_town_pref**) はダウンロード対象外
+      { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town/pref/mt_town_pref13.csv.zip" }] },
 
       // 東京都千代田区 (131016)
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town/city/mt_town_city131016.csv.zip" }] },
@@ -35,6 +39,9 @@ const PackageListResponse = {
       // 京都府データ (26....)
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_city/pref/mt_city_pref26.csv.zip" }] },
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_city_pos/pref/mt_city_pos_pref26.csv.zip" }] },
+      { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town_pos/pref/mt_town_pos_pref26.csv.zip" }] },
+      // town は city スコープ版で取得するため、pref レベル (mt_town_pref**) はダウンロード対象外
+      { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town/pref/mt_town_pref26.csv.zip" }] },
 
       // 京都府福知山市 (262013)
       { description: "最終更新日: 2025-09-30T15:41:43.000Z", distribution: [{ accessURL: "https://example.com/mt_town/city/mt_town_city262013.csv.zip" }] },

--- a/src/usecases/download/__tests__/download-process.test.ts
+++ b/src/usecases/download/__tests__/download-process.test.ts
@@ -132,6 +132,15 @@ describe('Downloader', () => {
     expect(lgCodeDatasetPairs).toContain('131016:parcel');
     expect(lgCodeDatasetPairs).toContain('262013:town');
     expect(lgCodeDatasetPairs).toContain('000000:pref');
+    // 都道府県レベルの位置参照拡張 (mt_town_pos_pref**.csv) もダウンロード対象に含めること
+    expect(lgCodeDatasetPairs).toContain('26....:town_pos');
+    // town は city スコープ版 (mt_town_city**) で取得するため、pref レベル (mt_town_pref**) は対象外
+    expect(lgCodeDatasetPairs).not.toContain('26....:town');
+
+    // 市区町村LGCode単独指定 (131016) でも、pref-only の town_pos は都道府県(13....)から取得すること。
+    // 一方 pref レベルの town は取得せず、要求した区の city 版だけにとどめること (全都道府県の町字を巻き込まない)。
+    expect(lgCodeDatasetPairs).toContain('13....:town_pos');
+    expect(lgCodeDatasetPairs).not.toContain('13....:town');
   });
 
 

--- a/src/usecases/download/download-process.ts
+++ b/src/usecases/download/download-process.ts
@@ -298,9 +298,10 @@ export class Downloader {
         if (downloadTargetLgCodes.size > 0 && !cityPrefixes.has(prefix)) {
           continue;
         }
-        // city, city_pos に加えて、都道府県レベルのrsdtdsp系ファイルも含める
-        for (const dataset of ['city', 'city_pos', 'rsdtdsp_blk', 'rsdtdsp_blk_pos', 'rsdtdsp_rsdt', 'rsdtdsp_rsdt_pos'] as FileGroupKey[]) {
-          const packageId = lgCodePackages.get(lgCode)?.get(dataset);
+        // city, city_pos, town_pos と都道府県レベルの rsdtdsp 系ファイルを含める。
+        // town は city スコープ版 (mt_town_city**) を別途取得するため、pref レベルでは取得しない。
+        for (const dataset of ['city', 'city_pos', 'town_pos', 'rsdtdsp_blk', 'rsdtdsp_blk_pos', 'rsdtdsp_rsdt', 'rsdtdsp_rsdt_pos'] as FileGroupKey[]) {
+          const packageId = packages.get(dataset);
           if (packageId) {
             results.push({
               kind: 'download',


### PR DESCRIPTION
## 概要

Version 2 系の最終リリース (v2.3.0)。以下を含む。

- **バグ修正**: `abrg download -c <LGCode>` で都道府県レベルの位置参照拡張
  `mt_town_pos_pref**.csv` がダウンロードされない問題を修正
- 依存更新: `node-gyp` `^10.2.0` → `^12.3.0` / `jest-junit` `^16.0.0` → `^17.0.0`
- README に v2.3.0 リリースノートを追記

## バグ修正の詳細: pref レベルの town_pos が取得されない

### 症状
`abrg download -c 130001`（都道府県指定）や `-c 131016`（市区町村単独指定）で、
町字マスター位置参照拡張（都道府県単位, `mt_town_pos_pref**.csv`）がダウンロード
対象から漏れていた。この結果、町字の代表点座標（`rep_lat`/`rep_lon`）が DB に
取り込まれない。

### 原因
ダウンロード対象を決める際、都道府県レベルでは取得するデータセットを明示リストで
列挙しているが、そのリストに `town_pos` が含まれていなかった。

### 修正
都道府県レベルの明示リストに `town_pos` を追加した。

### なぜ `town`（`mt_town_pref**`）は追加しないのか
ABR カタログ上、`town_pos` は **pref スコープにしか存在しない**（city スコープ版が
無い）ため、都道府県レベルで取得しないと一切取得できない。一方 `town` は
**city スコープ版（`mt_town_city**`）が別途存在**し、都道府県・市区町村いずれの
指定でも要求した市区町村分が取得される。pref レベルでも `town` を取ると同じ町字
データの二重取得になり、特に `-c 131016`（千代田区のみ）のような単独指定時に
その都道府県の全町字を巻き込む。したがって `town` は pref レベルでは意図的に
取得しない（要求した市区町村の町字データ自体は city スコープ版で取得されるため、
取りこぼしは無い）。

## 検証

- **ユニットテスト**: 都道府県指定パス（`26....`）と市区町村単独指定パス
  （`131016 → 13....` を発火）の両方で、`town_pos` が pref から取得され、
  pref レベルの `town` は対象外になることを確認。
- **実ダウンロード〜取り込み**: `abrg download -c 312011`（鳥取市）で
  `mt_town_pos_pref31.csv.zip` が取得され、`mt_town_pref31`（pref town）は
  取得されないことを確認。さらに取り込み後の `common.sqlite` の `town` テーブルで
  `rep_lat`/`rep_lon` が投入され（2460/2463 行）、鳥取県の範囲の正しい座標に
  なっていることを確認。