### PR TITLE
fix(abrdb): honor proxy env vars in download client (re: #85)

### DIFF
--- a/abrdb/internal/infra/api/client.go
+++ b/abrdb/internal/infra/api/client.go
@@ -46,14 +46,15 @@ func New(feedURL string) *Client {
 	// Configure transport to match AWS SDK v2 defaults
 	// AWS SDK uses conservative settings that work well with S3/CloudFront
 	transport := &http.Transport{
-		MaxIdleConns:          100,              // AWS SDK default
-		MaxIdleConnsPerHost:   10,               // AWS SDK default - key setting!
-		MaxConnsPerHost:       0,                // Unlimited (AWS SDK default)
-		IdleConnTimeout:       90 * time.Second, // AWS SDK default
-		TLSHandshakeTimeout:   10 * time.Second, // AWS SDK default
-		ExpectContinueTimeout: 1 * time.Second,  // AWS SDK default
-		DisableCompression:    false,            // AWS SDK enables compression
-		ForceAttemptHTTP2:     true,             // Try HTTP/2 like AWS SDK
+		Proxy:                 http.ProxyFromEnvironment, // honor HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+		MaxIdleConns:          100,                       // AWS SDK default
+		MaxIdleConnsPerHost:   10,                        // AWS SDK default - key setting!
+		MaxConnsPerHost:       0,                         // Unlimited (AWS SDK default)
+		IdleConnTimeout:       90 * time.Second,          // AWS SDK default
+		TLSHandshakeTimeout:   10 * time.Second,          // AWS SDK default
+		ExpectContinueTimeout: 1 * time.Second,           // AWS SDK default
+		DisableCompression:    false,                     // AWS SDK enables compression
+		ForceAttemptHTTP2:     true,                      // Try HTTP/2 like AWS SDK
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second, // AWS SDK default
 			KeepAlive: 30 * time.Second, // AWS SDK default

--- a/abrdb/internal/infra/api/client_http_test.go
+++ b/abrdb/internal/infra/api/client_http_test.go
@@ -11,6 +11,22 @@ import (
 	"time"
 )
 
+func TestNewClientHonorsProxyEnv(t *testing.T) {
+	// The download client must route through HTTP(S)_PROXY when set (corporate
+	// proxy environments). A hand-built http.Transport defaults to Proxy=nil,
+	// which silently ignores the proxy env vars — this guards against that.
+	tr, ok := New("https://example.com/feed.json").httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", New("").httpClient.Transport)
+	}
+	// A hand-built http.Transport defaults to Proxy=nil, which silently ignores
+	// HTTP_PROXY/HTTPS_PROXY. The client must set Proxy so corporate proxy
+	// environments work.
+	if tr.Proxy == nil {
+		t.Fatal("Transport.Proxy is nil; HTTP_PROXY/HTTPS_PROXY would be ignored")
+	}
+}
+
 func TestMatchesPrefix(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## 概要

`abrdb` のダウンロードクライアント (`internal/infra/api/client.go`) が、手組みの `http.Transport` で `Proxy` を設定しておらず、`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` を無視して常に直結していた問題を修正します。

Go では `http.DefaultTransport` は `Proxy: http.ProxyFromEnvironment` を持ちますが、手組みの `http.Transport{}` は `Proxy: nil`（プロキシ不使用）がデフォルトです。このため社内プロキシ環境では ABR API へのダウンロードが失敗し、環境変数を設定しても効きませんでした。

## 変更

- `transport` に `Proxy: http.ProxyFromEnvironment` を追加し、標準のプロキシ環境変数を尊重
- 回帰防止テスト `TestNewClientHonorsProxyEnv` を追加（transport が `Proxy` を持つことを検証）

プロキシ環境変数が未設定の場合は従来どおり直結のため、プロキシ無し環境への影響はありません。

## 関連

#85（Proxy 環境における動作の確認）の Linux/プロキシ側の事象に対応します。Windows 非WSL 環境の不動作は本 PR の対象外です。
