### PR TITLE
feat(terraform): allow overriding CORS allow-origin from root module

### DIFF
--- a/docs/aws/terraform/main.tf
+++ b/docs/aws/terraform/main.tf
@@ -38,6 +38,10 @@ locals {
   abrg_memory        = "8192" # 8 GB
   log_level          = "info"
   log_retention_days = 30
+
+  # Public read-only API, so "'*'" is the default. Restrict to specific
+  # origins (e.g. "'https://example.com'") for authenticated or internal use.
+  cors_allow_origin = "'*'"
 }
 
 module "network" {
@@ -97,6 +101,7 @@ module "api_gateway" {
 
   stage_name         = local.api_stage_name
   log_retention_days = local.log_retention_days
+  cors_allow_origin  = local.cors_allow_origin
 }
 
 module "workflow" {


### PR DESCRIPTION
## 概要

`docs/aws/terraform` のサンプル構成で、CORS の `Access-Control-Allow-Origin` をルートモジュールから上書きできるように配線しました。

これまで `cors_allow_origin` は `modules/api_gateway` 側に変数の口はあったものの、ルートの `module "api_gateway"` から渡されておらず、モジュール内のデフォルト `'*'` が常に使われる状態でした。値を絞りたくても変更する手段がない状態を解消します。

## 変更内容

- ルート `main.tf` の `locals` に `cors_allow_origin` を追加（既存スタイルに合わせ locals 方式）
- `module "api_gateway"` へ `cors_allow_origin = local.cors_allow_origin` を渡す

デフォルトは `'*'` のまま据え置きです。公開読み取り前提の API のため既定値は変えず、用途を変える場合に絞れる導線だけを用意しています。

## 互換性

変更前後でデフォルト値は `'*'` のまま同一のため、既存デプロイへの影響はありません。

値を絞った場合に差分が出るのは `aws_api_gateway_integration_response` の `proxy_options` / `root_options` の2リソースのみです。