### PR TITLE
fix(abrg): 数字のみの小字のマッチングと住所文字列の数字境界区切り (#259, #260)

### DIFF
--- a/abrg/internal/matching/fallback.go
+++ b/abrg/internal/matching/fallback.go
@@ -3,6 +3,7 @@ package matching
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"abrg/internal/matching/levenshtein"
 	"abrg/internal/model"
@@ -92,6 +93,19 @@ func (n *Impl) handleBasicFallback(ctx context.Context, nctx *normalizeContext) 
 		}
 	}
 
+	// Numeric-only koaza (e.g., 七尾市大田町111): the number was split off as a
+	// chome/parcel candidate, but those interpretations have all failed by this
+	// point, so try it as part of the machiaza name. (issue #259)
+	if basic.StructuredAddress.Chome == nil && basic.StructuredAddress.Koaza == nil {
+		results, err := n.tryNumericKoazaSearch(ctx, nctx)
+		if err != nil {
+			return nil, err
+		}
+		if results != nil {
+			return results, nil
+		}
+	}
+
 	// Set unmatched address if not already computed
 	// Skip if Levenshtein fallback was used (UnmatchedAddress already computed correctly)
 	// Pass original searchAddr so extractUnmatchedWithColonNoAt can detect chome patterns
@@ -118,6 +132,47 @@ func (n *Impl) tryChomeSearch(ctx context.Context, nctx *normalizeContext) ([]mo
 	}
 
 	setUnmatchedAddress(&results[0], nctx.Input.NormalizedAddr, nctx.Input.StandardizedAddr, results[0].MatchedAddress, nctx.Input.SearchAddr.String())
+	return results, nil
+}
+
+// tryNumericKoazaSearch interprets the first number part as a numeric-only koaza
+// (e.g., "7尾市大田町:111" → normalized_address "7尾市大田町111"). Numeric koaza
+// records are stored without the chome marker "@", so neither the base search nor
+// the chome fallback can reach them. Remaining numbers are resolved as a parcel
+// under the koaza's machiaza (e.g., 大田町111-11 → 地番11).
+func (n *Impl) tryNumericKoazaSearch(ctx context.Context, nctx *normalizeContext) ([]model.MatchedResult, error) {
+	sa := nctx.Input.SearchAddr
+	if sa.HasChome || sa.LeadingHyphen || sa.Base == "" || len(sa.Numbers) == 0 {
+		return nil, nil
+	}
+
+	results, err := queryAddressResults(ctx, n.repo, sa.Base+sa.Numbers[0], nctx.Input.Pref, nctx.Input.NormalizedAddr)
+	if err != nil {
+		return nil, fmt.Errorf("numeric koaza search: %w", err)
+	}
+	if len(results) == 0 || results[0].StructuredAddress.Koaza == nil {
+		return nil, nil
+	}
+	koaza := &results[0]
+
+	// Consume the first number into the base so unmatched calculation sees the rest only.
+	consumed := nctx.Input.SearchAddr
+	consumed.Base = sa.Base + sa.Numbers[0]
+	consumed.Numbers = sa.Numbers[1:]
+
+	if len(consumed.Numbers) > 0 && n.twoStageSearch != nil {
+		parcelAddr := consumed.Base + ":" + strings.Join(consumed.Numbers, "-")
+		parcelResults, err := n.twoStageSearch.normalizeWithBasic(ctx, model.CategoryParcel, results, parcelAddr)
+		if err != nil {
+			return nil, err
+		}
+		if len(parcelResults) > 0 {
+			setTwoStageUnmatchedAddress(&parcelResults[0], nctx.Input.StandardizedAddr, parcelAddr)
+			return parcelResults, nil
+		}
+	}
+
+	setUnmatchedAddress(koaza, nctx.Input.NormalizedAddr, nctx.Input.StandardizedAddr, koaza.MatchedAddress, consumed.String())
 	return results, nil
 }
 

--- a/abrg/internal/matching/fallback.go
+++ b/abrg/internal/matching/fallback.go
@@ -155,13 +155,14 @@ func (n *Impl) tryNumericKoazaSearch(ctx context.Context, nctx *normalizeContext
 	}
 	koaza := &results[0]
 
-	// Consume the first number into the base so unmatched calculation sees the rest only.
-	consumed := nctx.Input.SearchAddr
-	consumed.Base = sa.Base + sa.Numbers[0]
-	consumed.Numbers = sa.Numbers[1:]
+	// Consume the first number into the base; the building name is deliberately
+	// excluded from the search string because setTwoStageUnmatchedAddress recovers
+	// it from the normalized address (including it here would duplicate the entry).
+	base := sa.Base + sa.Numbers[0]
+	rest := sa.Numbers[1:]
 
-	if len(consumed.Numbers) > 0 && n.twoStageSearch != nil {
-		parcelAddr := consumed.Base + ":" + strings.Join(consumed.Numbers, "-")
+	if len(rest) > 0 && n.twoStageSearch != nil {
+		parcelAddr := base + ":" + strings.Join(rest, "-")
 		parcelResults, err := n.twoStageSearch.normalizeWithBasic(ctx, model.CategoryParcel, results, parcelAddr)
 		if err != nil {
 			return nil, err
@@ -172,7 +173,7 @@ func (n *Impl) tryNumericKoazaSearch(ctx context.Context, nctx *normalizeContext
 		}
 	}
 
-	setUnmatchedAddress(koaza, nctx.Input.NormalizedAddr, nctx.Input.StandardizedAddr, koaza.MatchedAddress, consumed.String())
+	setTwoStageUnmatchedAddress(koaza, nctx.Input.StandardizedAddr, base)
 	return results, nil
 }
 

--- a/abrg/internal/matching/issues/issue201_test.go
+++ b/abrg/internal/matching/issues/issue201_test.go
@@ -15,9 +15,9 @@ import (
 func TestIssue201(t *testing.T) {
 	runNormalizeTests(t, []normalizeTestCase{
 		{
-			// 石川県加賀市大聖寺上木町 - 九十五は存在しない小字
-			// Node.js版では「九十五五」になっていた
-			// Go版では町字までマッチし、九十五はunmatchedに残る（元の形式を保持）
+			// 石川県加賀市大聖寺上木町 - 小字「九十五」(正規化形95) にマッチ（issue #259）
+			// Node.js版では「九十五五」と末尾の漢数字が重複していた。
+			// 重複せず「九十五」のまま小字としてマッチすることを確認する。
 			name: "issue201-1 [石川県加賀市大聖寺上木町九十五]",
 			query: model.MatchQuery{
 				Address:  "石川県加賀市大聖寺上木町九十五",
@@ -25,9 +25,9 @@ func TestIssue201(t *testing.T) {
 				Pref:     "all",
 				Limit:    1,
 			},
-			wantMatchLevel:       model.MatchLevelMachiaza,
-			wantMatchedAddress:   "石川県加賀市大聖寺上木町",
-			wantUnmatchedAddress: []string{"九十五"}, // 九十五は元の形式を保持してunmatchedに残る
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県加賀市大聖寺上木町九十五",
+			wantUnmatchedAddress: nil,
 			wantStructured: map[string]any{
 				FieldPref:         "石川県",
 				FieldCounty:       nil,
@@ -37,7 +37,7 @@ func TestIssue201(t *testing.T) {
 				FieldKyotoSt:      nil,
 				FieldOazaCho:      "大聖寺上木町",
 				FieldChome:        nil,
-				FieldKoaza:        nil,
+				FieldKoaza:        "九十五",
 				FieldBlkNum:       nil,
 				FieldRsdtNum:      nil,
 				FieldRsdtNum2:     nil,

--- a/abrg/internal/matching/issues/issue259_test.go
+++ b/abrg/internal/matching/issues/issue259_test.go
@@ -77,6 +77,44 @@ func TestIssue259(t *testing.T) {
 				FieldKoaza:   "1",
 			},
 		},
+		// 数字小字 + 建物名（小字のみで止まる経路でもビル名が unmatched に残ること）
+		{
+			name: "issue259-6 [七尾市大田町111 大田ビル202]",
+			query: model.MatchQuery{
+				Address:  "七尾市大田町111 大田ビル202",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県七尾市大田町111",
+			wantUnmatchedAddress: []string{"大田ビル202"},
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "大田町",
+				FieldKoaza:   "111",
+			},
+		},
+		// 数字小字 + 地番 + 建物名（地番まで進む経路）
+		{
+			name: "issue259-7 [七尾市大田町111-11 大田ビル202]",
+			query: model.MatchQuery{
+				Address:  "七尾市大田町111-11 大田ビル202",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantUnmatchedAddress: []string{"大田ビル202"},
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "大田町",
+				FieldKoaza:   "111",
+				FieldPrcNum1: "11",
+			},
+		},
 		// 回帰確認: 丁目解釈が優先されること（紀尾井町1-3 は従来どおり住居表示）
 		{
 			name: "issue259-4 [東京都千代田区紀尾井町1-3] 回帰",

--- a/abrg/internal/matching/issues/issue259_test.go
+++ b/abrg/internal/matching/issues/issue259_test.go
@@ -1,0 +1,121 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue259 tests matching of numeric-only koaza with half-width digit input
+// Issue #259: 数字のみの小字（例: 七尾市大田町111）が半角数字入力でマッチしない
+// https://github.com/digital-go-jp/abr-geocoder/issues/259
+//
+// 問題:
+// - 「七尾市大田町壱壱壱-11」→ koaza=111 の小字にマッチし parcel まで到達する
+// - 「七尾市大田町111-11」　→ 大田町の基底で止まり「111-11」が unmatched になる
+//
+// 同一の小字を指す2表記で結果が異なる。数字小字は AddColon で丁目/地番として
+// 分割され、フォールバックも丁目マーカー付き（base+数字+@）しか照会しないため、
+// @なしで格納されている数字小字レコードに到達できない。
+func TestIssue259(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		// 数字小字そのもの（石川県七尾市大田町 小字111 = machiaza_id 0022145）
+		{
+			name: "issue259-1 [七尾市大田町111]",
+			query: model.MatchQuery{
+				Address:  "七尾市大田町111",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県七尾市大田町111",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "大田町",
+				FieldChome:   nil,
+				FieldKoaza:   "111",
+			},
+		},
+		// 数字小字 + 地番（漢数字入力「壱壱壱-11」と同じ結果になるべき）
+		{
+			name: "issue259-2 [七尾市大田町111-11]",
+			query: model.MatchQuery{
+				Address:  "七尾市大田町111-11",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "大田町",
+				FieldKoaza:   "111",
+				FieldPrcNum1: "11",
+			},
+		},
+		// 1桁の数字小字（輪島市大野町 小字1 = machiaza_id 0010101）
+		{
+			name: "issue259-3 [石川県輪島市大野町1]",
+			query: model.MatchQuery{
+				Address:  "石川県輪島市大野町1",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県輪島市大野町1",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "輪島市",
+				FieldOazaCho: "大野町",
+				FieldChome:   nil,
+				FieldKoaza:   "1",
+			},
+		},
+		// 回帰確認: 丁目解釈が優先されること（紀尾井町1-3 は従来どおり住居表示）
+		{
+			name: "issue259-4 [東京都千代田区紀尾井町1-3] 回帰",
+			query: model.MatchQuery{
+				Address:  "東京都千代田区紀尾井町1-3",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelResidentialDetail,
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "東京都",
+				FieldCity:    "千代田区",
+				FieldOazaCho: "紀尾井町",
+				FieldKoaza:   nil,
+				FieldBlkNum:  "1",
+				FieldRsdtNum: "3",
+			},
+		},
+		// 回帰確認: 通常の地番（町名+数字が町字に存在しないケース）
+		{
+			name: "issue259-5 [茨城県つくば市筑穂1-10-4] 回帰",
+			query: model.MatchQuery{
+				Address:  "茨城県つくば市筑穂1-10-4",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "茨城県",
+				FieldCity:    "つくば市",
+				FieldOazaCho: "筑穂",
+				FieldChome:   "1丁目",
+				FieldPrcNum1: "10",
+				FieldPrcNum2: "4",
+			},
+		},
+	})
+}

--- a/abrg/internal/matching/issues/issue260_test.go
+++ b/abrg/internal/matching/issues/issue260_test.go
@@ -1,0 +1,111 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue260 tests separator insertion between digit-ending and digit-starting parts
+// Issue #260: 数字で終わる要素と数字で始まる要素が区切りなしで連結される
+// https://github.com/digital-go-jp/abr-geocoder/issues/260
+//
+// 問題:
+// - 「七尾市大田町111-11」（小字111 + 地番11）→ matched_address が「大田町11111」になる
+//
+// FormatAddress は要素を順に連結するだけで、数字終わり×数字始まりの境界に
+// 区切りが入らない。直前の文字が ASCII 数字で次の要素も数字で始まる場合は
+// 「-」を挿入する。
+func TestIssue260(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name string
+		sa   model.StructuredAddress
+		want string
+	}{
+		// 数字小字 + 地番（issue 報告の具体例）
+		{
+			name: "issue260-1 [大田町111 + 地番11]",
+			sa: model.StructuredAddress{
+				Pref: strPtr("石川県"), City: strPtr("七尾市"),
+				OazaCho: strPtr("大田町"), Koaza: strPtr("111"),
+				PrcNum1: strPtr("11"),
+			},
+			want: "石川県七尾市大田町111-11",
+		},
+		// 数字小字 + 街区・住居番号
+		{
+			name: "issue260-2 [大田町111 + 街区2 住居5]",
+			sa: model.StructuredAddress{
+				Pref: strPtr("石川県"), City: strPtr("七尾市"),
+				OazaCho: strPtr("大田町"), Koaza: strPtr("111"),
+				BlkNum: strPtr("2"), RsdtNum: strPtr("5"),
+			},
+			want: "石川県七尾市大田町111-2-5",
+		},
+		// 漢数字小字は数字で終わらないので区切り不要（従来どおり）
+		{
+			name: "issue260-3 [大田町壱壱壱 + 地番11] 区切りなし",
+			sa: model.StructuredAddress{
+				Pref: strPtr("石川県"), City: strPtr("七尾市"),
+				OazaCho: strPtr("大田町"), Koaza: strPtr("壱壱壱"),
+				PrcNum1: strPtr("11"),
+			},
+			want: "石川県七尾市大田町壱壱壱11",
+		},
+		// 小字が数字以外で終わる場合も区切り不要（従来どおり）
+		{
+			name: "issue260-4 [大聖寺上木町95の + 地番7] 区切りなし",
+			sa: model.StructuredAddress{
+				Pref: strPtr("石川県"), City: strPtr("加賀市"),
+				OazaCho: strPtr("大聖寺上木町"), Koaza: strPtr("95の"),
+				PrcNum1: strPtr("7"),
+			},
+			want: "石川県加賀市大聖寺上木町95の7",
+		},
+		// 既存の区切り（街区-住居、地番間）は二重にならない
+		{
+			name: "issue260-5 [紀尾井町1-3] 回帰",
+			sa: model.StructuredAddress{
+				Pref: strPtr("東京都"), City: strPtr("千代田区"),
+				OazaCho: strPtr("紀尾井町"), BlkNum: strPtr("1"),
+				RsdtNum: strPtr("3"),
+			},
+			want: "東京都千代田区紀尾井町1-3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.FormatAddress(&tt.sa)
+			if got != tt.want {
+				t.Errorf("FormatAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIssue260EndToEnd verifies the matched_address via the full matching path.
+func TestIssue260EndToEnd(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		{
+			name: "issue260-e2e [七尾市大田町111-11]",
+			query: model.MatchQuery{
+				Address:  "七尾市大田町111-11",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantMatchedAddress:   "石川県七尾市大田町111-11",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "大田町",
+				FieldKoaza:   "111",
+				FieldPrcNum1: "11",
+			},
+		},
+	})
+}

--- a/abrg/internal/matching/issues/japanese_address_testdata_test.go
+++ b/abrg/internal/matching/issues/japanese_address_testdata_test.go
@@ -1123,8 +1123,8 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 		},
 		{
 			// 字名「ノ」のあとにハイフンで地番が続く
-			// 入力「軽海町ノ－１４－１」→「軽海町」にマッチ（ハイフン後がノと分離）
-			// TODO: 字名「ノ－」として認識できるように改善検討
+			// 入力「軽海町ノ－１４－１」→ 小字「ノ」+ 地番14-1 にマッチ（issue #259 の
+			// 小字フォールバックにより字名として解決できるようになった）
 			name: "jat035 [石川県小松市軽海町ノ－１４－１]",
 			query: model.MatchQuery{
 				Address:  "石川県小松市軽海町ノ－１４－１",
@@ -1132,9 +1132,9 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				Pref:     "all",
 				Limit:    1,
 			},
-			wantMatchLevel:       model.MatchLevelMachiaza,
-			wantMatchedAddress:   "石川県小松市軽海町",
-			wantUnmatchedAddress: []string{"ノ-14-1"},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantMatchedAddress:   "石川県小松市軽海町ノ14-1",
+			wantUnmatchedAddress: nil,
 			wantStructured: map[string]any{
 				"pref":          "石川県",
 				"county":        nil,
@@ -1144,12 +1144,12 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				"kyoto_st":      nil,
 				"oaza_cho":      "軽海町",
 				"chome":         nil,
-				"koaza":         nil,
+				"koaza":         "ノ",
 				"blk_num":       nil,
 				"rsdt_num":      nil,
 				"rsdt_num2":     nil,
-				"prc_num1":      nil,
-				"prc_num2":      nil,
+				"prc_num1":      "14",
+				"prc_num2":      "1",
 				"prc_num3":      nil,
 			},
 		},
@@ -3159,7 +3159,7 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 		},
 		{
 			// 数字の字（勝林寺）
-			// 「三木町34」→34は字として未対応、町字止まり
+			// 「三木町34」→ 小字「参四」(正規化形34) + 地番25 にマッチ（issue #259）
 			name: "jat076 [石川県加賀市三木町34-25]",
 			query: model.MatchQuery{
 				Address:  "石川県加賀市三木町34-25",
@@ -3167,9 +3167,9 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				Pref:     "all",
 				Limit:    1,
 			},
-			wantMatchLevel:       model.MatchLevelMachiaza,
-			wantMatchedAddress:   "石川県加賀市三木町",
-			wantUnmatchedAddress: []string{"34-25"},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantMatchedAddress:   "石川県加賀市三木町参四25",
+			wantUnmatchedAddress: nil,
 			wantStructured: map[string]any{
 				"pref":          "石川県",
 				"county":        nil,
@@ -3179,11 +3179,11 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				"kyoto_st":      nil,
 				"oaza_cho":      "三木町",
 				"chome":         nil,
-				"koaza":         nil,
+				"koaza":         "参四",
 				"blk_num":       nil,
 				"rsdt_num":      nil,
 				"rsdt_num2":     nil,
-				"prc_num1":      nil,
+				"prc_num1":      "25",
 				"prc_num2":      nil,
 				"prc_num3":      nil,
 			},
@@ -3219,7 +3219,8 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 			},
 		},
 		{
-			// jat076の補足：「34の25」とすると「34の」が小字として認識されずmachiaza止まり
+			// jat076の補足：「34の25」は「の」がハイフン化され jat076 と同じ解釈になる
+			// （小字「参四」+ 地番25。issue #259）
 			name: "jat076-2 [石川県加賀市三木町34の25]",
 			query: model.MatchQuery{
 				Address:  "石川県加賀市三木町34の25",
@@ -3227,9 +3228,9 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				Pref:     "all",
 				Limit:    1,
 			},
-			wantMatchLevel:       model.MatchLevelMachiaza,
-			wantMatchedAddress:   "石川県加賀市三木町",
-			wantUnmatchedAddress: []string{"34-25"},
+			wantMatchLevel:       model.MatchLevelParcel,
+			wantMatchedAddress:   "石川県加賀市三木町参四25",
+			wantUnmatchedAddress: nil,
 			wantStructured: map[string]any{
 				"pref":          "石川県",
 				"county":        nil,
@@ -3239,11 +3240,11 @@ func TestJapaneseAddressTestdata(t *testing.T) {
 				"kyoto_st":      nil,
 				"oaza_cho":      "三木町",
 				"chome":         nil,
-				"koaza":         nil,
+				"koaza":         "参四",
 				"blk_num":       nil,
 				"rsdt_num":      nil,
 				"rsdt_num2":     nil,
-				"prc_num1":      nil,
+				"prc_num1":      "25",
 				"prc_num2":      nil,
 				"prc_num3":      nil,
 			},

--- a/abrg/internal/model/address.go
+++ b/abrg/internal/model/address.go
@@ -134,49 +134,62 @@ func (dst *StructuredAddress) MergeFrom(src *StructuredAddress) {
 // FormatAddress constructs formatted address from StructuredAddress components including numbers.
 // MachiazaDist is a disambiguator for same-named machiaza (e.g. kana reading), not part of
 // the address notation, so it is intentionally excluded here.
+// A "-" is inserted wherever a digit-ending part would otherwise touch a digit-starting
+// part (e.g. numeric koaza "111" + parcel "11" → "111-11", not "11111").
 func FormatAddress(sa *StructuredAddress) string {
-	var sb strings.Builder
-	sb.Grow(256)
+	w := addressWriter{}
+	w.sb.Grow(256)
 
 	// Build base address parts
-	writeStringPtr(&sb, sa.Pref)
-	writeStringPtr(&sb, sa.County)
-	writeStringPtr(&sb, sa.City)
-	writeStringPtr(&sb, sa.Ward)
-	writeStringPtr(&sb, sa.KyotoSt)
-	writeStringPtr(&sb, sa.OazaCho)
-	writeStringPtr(&sb, sa.Chome)
-	writeStringPtr(&sb, sa.Koaza)
+	w.write(sa.Pref, "")
+	w.write(sa.County, "")
+	w.write(sa.City, "")
+	w.write(sa.Ward, "")
+	w.write(sa.KyotoSt, "")
+	w.write(sa.OazaCho, "")
+	w.write(sa.Chome, "")
+	w.write(sa.Koaza, "")
 
 	// Residential addresses (BlkNum, RsdtNum, RsdtNum2)
-	writeStringPtr(&sb, sa.BlkNum)
-	if hasValue(sa.RsdtNum) {
-		if hasValue(sa.BlkNum) {
-			sb.WriteString("-")
-		}
-		sb.WriteString(*sa.RsdtNum)
+	w.write(sa.BlkNum, "")
+	if hasValue(sa.BlkNum) {
+		w.write(sa.RsdtNum, "-")
+	} else {
+		w.write(sa.RsdtNum, "")
 	}
-	writeWithPrefix(&sb, sa.RsdtNum2, "-")
+	w.write(sa.RsdtNum2, "-")
 
 	// Parcel addresses (PrcNum1, PrcNum2, PrcNum3)
-	writeStringPtr(&sb, sa.PrcNum1)
-	writeWithPrefix(&sb, sa.PrcNum2, "-")
-	writeWithPrefix(&sb, sa.PrcNum3, "-")
+	w.write(sa.PrcNum1, "")
+	w.write(sa.PrcNum2, "-")
+	w.write(sa.PrcNum3, "-")
 
-	return sb.String()
+	return w.sb.String()
 }
 
-func writeStringPtr(sb *strings.Builder, ptr *string) {
-	if ptr != nil && *ptr != "" {
-		sb.WriteString(*ptr)
-	}
+// addressWriter concatenates address parts, separating adjacent digits across parts.
+type addressWriter struct {
+	sb   strings.Builder
+	last byte
 }
 
-func writeWithPrefix(sb *strings.Builder, ptr *string, prefix string) {
-	if ptr != nil && *ptr != "" {
-		sb.WriteString(prefix)
-		sb.WriteString(*ptr)
+func (w *addressWriter) write(ptr *string, prefix string) {
+	if ptr == nil || *ptr == "" {
+		return
 	}
+	s := *ptr
+	switch {
+	case prefix != "":
+		w.sb.WriteString(prefix)
+	case isASCIIDigit(w.last) && isASCIIDigit(s[0]):
+		w.sb.WriteString("-")
+	}
+	w.sb.WriteString(s)
+	w.last = s[len(s)-1]
+}
+
+func isASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }
 
 func hasValue(ptr *string) bool {


### PR DESCRIPTION
## 概要

数字のみの小字に関する2件の修正。

- Closes #259 — 数字のみの小字（例: 七尾市大田町の小字「111」）が半角数字入力でマッチしない
- Closes #260 — 数字で終わる要素と数字で始まる要素が区切りなしで連結される

## 変更内容

### 数字小字のマッチング (#259)

`handleBasicFallback` に小字解釈のフォールバックを追加。丁目・住居表示・地番のすべての解釈が失敗した後に、先頭の数字部分を町字名の一部として（丁目マーカー `@` なしで）照会し、当たれば残りの数字をその小字配下の地番として解決する。

- 数字小字レコードの `normalized_address` は `@` なしで格納されているため、従来の基底検索・丁目フォールバック（`base+N+@`）のいずれからも到達できなかった
- フォールバックの最後に置くことで、基底町字に同番の地番が実在する曖昧ケース（全国 1,161 件）は従来の地番優先のまま変わらない
- 通常の地番（例: 米花町492-1）は該当する町字が存在しないため挙動不変

既存テスト3件の期待値を更新。いずれも「小字に到達できない」旧挙動のスナップショットで、対応する小字レコード（加賀市大聖寺上木町「九十五」、三木町「参四」、小松市軽海町「ノ」）は現在の ABR データに実在する。

### 数字境界の区切り挿入 (#260)

`FormatAddress` に汎用規則を追加: 直前に書いた文字が ASCII 数字で、次に書く要素も数字で始まり、他の区切りが入らない場合は `-` を挿入する。

- 小字「111」+ 地番「11」→ `大田町111-11`（従来は `大田町11111`）
- 小字→地番の特例ではなく境界一般の規則とし、表記改訂への耐性を持たせた
- 漢数字小字（`壱壱壱11`）等、数字で終わらない要素は従来どおり
