### PR TITLE
fix(abrg): rsdt_addr_flg を住居表示マッチは1固定・混在町字の町字マッチはnullにする (#262)

### DIFF
--- a/abrg/internal/matching/detect_machiaza.go
+++ b/abrg/internal/matching/detect_machiaza.go
@@ -234,6 +234,7 @@ func queryAddressResults(ctx context.Context, repo basicFinder, address string, 
 	for i := range basicResults {
 		results = append(results, repository.BasicResultToNormalized(&basicResults[i]))
 	}
+	ambiguousFlg := hasAmbiguousRsdtAddrFlg(results)
 
 	// Select best match when multiple candidates exist
 	if len(results) > 1 {
@@ -248,5 +249,34 @@ func queryAddressResults(ctx context.Context, repo basicFinder, address string, 
 		}
 	}
 
+	// A machiaza where 住居表示実施/非実施 coexist has one row per flag in ABR, so
+	// which side the address belongs to is unknown at machiaza level (issue #262).
+	// v2 represented this as AMBIGUOUS_RSDT_ADDR_FLG (-1); v3 uses null.
+	for i := range results {
+		if results[i].IDs.LgCode != nil && results[i].IDs.MachiazaID != nil &&
+			ambiguousFlg[*results[i].IDs.LgCode+*results[i].IDs.MachiazaID] {
+			results[i].IDs.RsdtAddrFlg = nil
+		}
+	}
+
 	return results, nil
+}
+
+// hasAmbiguousRsdtAddrFlg reports, per lg_code+machiaza_id, whether the candidates
+// contain rows with differing rsdt_addr_flg.
+func hasAmbiguousRsdtAddrFlg(results []model.MatchedResult) map[string]bool {
+	seen := make(map[string]string, len(results))
+	ambiguous := make(map[string]bool)
+	for i := range results {
+		ids := &results[i].IDs
+		if ids.LgCode == nil || ids.MachiazaID == nil || ids.RsdtAddrFlg == nil {
+			continue
+		}
+		key := *ids.LgCode + *ids.MachiazaID
+		if prev, ok := seen[key]; ok && prev != *ids.RsdtAddrFlg {
+			ambiguous[key] = true
+		}
+		seen[key] = *ids.RsdtAddrFlg
+	}
+	return ambiguous
 }

--- a/abrg/internal/matching/issues/issue262_test.go
+++ b/abrg/internal/matching/issues/issue262_test.go
@@ -1,0 +1,124 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"abrg/internal/model"
+)
+
+// TestIssue262 tests rsdt_addr_flg of residential matches in mixed areas
+// Issue #262: 住居表示マッチの rsdt_addr_flg が基底町字の値になる（混在地域で 0 が返る）
+// https://github.com/digital-go-jp/abr-geocoder/issues/262
+//
+// 問題:
+// - 「千葉県浦安市舞浜2-11」(category=rsdtdsp) → rsdt_addr_flg="0"
+// - マッチした町字（舞浜2丁目 0018002）の rsdt_addr_flg は 1。基底町字（0018000、
+//   混在地域のため flg 0/1 の2行）からフラグをマージしているのが原因。
+func TestIssue262(t *testing.T) {
+	normalizer := setupTestNormalizer(t)
+
+	tests := []struct {
+		name     string
+		query    model.MatchQuery
+		wantFlg  string // "" = null を期待
+		wantMcID string
+	}{
+		{
+			name: "issue262-1 [千葉県浦安市舞浜2-11 rsdtdsp]",
+			query: model.MatchQuery{
+				Address:  "千葉県浦安市舞浜2-11",
+				Category: model.CategoryResidential,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantFlg:  "1",
+			wantMcID: "0018002",
+		},
+		{
+			name: "issue262-2 [兵庫県三田市三輪2-1-1 all]",
+			query: model.MatchQuery{
+				Address:  "兵庫県三田市三輪2-1-1",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantFlg:  "1",
+			wantMcID: "0046002",
+		},
+	}
+
+	tests = append(tests, []struct {
+		name     string
+		query    model.MatchQuery
+		wantFlg  string
+		wantMcID string
+	}{
+		{
+			// 混在地域の町字マッチ: フラグが 0/1 の2行あるため不明 (null)。
+			// v2 は AMBIGUOUS_RSDT_ADDR_FLG = -1 を返していた
+			name: "issue262-3 [千葉県浦安市舞浜 (混在の基底町字)]",
+			query: model.MatchQuery{
+				Address:  "千葉県浦安市舞浜",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantFlg:  "",
+			wantMcID: "0018000",
+		},
+		{
+			// 丁目レベルでも混在があるケース
+			name: "issue262-4 [北海道札幌市中央区南9条西5丁目]",
+			query: model.MatchQuery{
+				Address:  "北海道札幌市中央区南9条西5丁目",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantFlg:  "",
+			wantMcID: "0074005",
+		},
+		{
+			// 単一フラグの町字マッチは従来どおり値を返す
+			name: "issue262-5 [東京都千代田区紀尾井町]",
+			query: model.MatchQuery{
+				Address:  "東京都千代田区紀尾井町",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantFlg:  "1",
+			wantMcID: "0056000",
+		},
+	}...)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp, err := normalizer.Match(context.Background(), tt.query)
+			if err != nil {
+				t.Fatalf("Match(%q) unexpected error: %v", tt.query.Address, err)
+			}
+			if len(resp.Features) == 0 {
+				t.Fatal("Match() returned no results")
+			}
+			ids := resp.Features[0].IDs
+			if ids.MachiazaID == nil || *ids.MachiazaID != tt.wantMcID {
+				t.Errorf("machiaza_id = %v, want %q", ids.MachiazaID, tt.wantMcID)
+			}
+			if tt.wantFlg == "" {
+				if ids.RsdtAddrFlg != nil {
+					t.Errorf("rsdt_addr_flg = %q, want nil", *ids.RsdtAddrFlg)
+				}
+				return
+			}
+			if ids.RsdtAddrFlg == nil {
+				t.Fatalf("rsdt_addr_flg = nil, want %q", tt.wantFlg)
+			}
+			if *ids.RsdtAddrFlg != tt.wantFlg {
+				t.Errorf("rsdt_addr_flg = %q, want %q", *ids.RsdtAddrFlg, tt.wantFlg)
+			}
+		})
+	}
+}

--- a/abrg/internal/matching/two_stage_search.go
+++ b/abrg/internal/matching/two_stage_search.go
@@ -205,9 +205,17 @@ func (s *twoStageSearch) normalizeWithBasic(
 		return nil, nil
 	}
 
-	// Merge IDs from basicResults (rsdt_addr_flg is not in cache_parcel or cache_rsdtdsp)
-	if result.IDs.RsdtAddrFlg == nil && basic.IDs.RsdtAddrFlg != nil {
-		result.IDs.RsdtAddrFlg = basic.IDs.RsdtAddrFlg
+	// rsdt_addr_flg is not in cache_parcel or cache_rsdtdsp. A residential match is
+	// by definition in the 住居表示実施 part of the machiaza, so the flag is always 1;
+	// inheriting it from basicResults would report the base machiaza's flag, which in
+	// mixed rsdtdsp/parcel areas is 0 or ambiguous (one row per flag) (issue #262).
+	if result.IDs.RsdtAddrFlg == nil {
+		if category == model.CategoryResidential {
+			flg := model.RsdtAddrFlgResidential
+			result.IDs.RsdtAddrFlg = &flg
+		} else if basic.IDs.RsdtAddrFlg != nil {
+			result.IDs.RsdtAddrFlg = basic.IDs.RsdtAddrFlg
+		}
 	}
 
 	// Merge basic address info from basicResults (avoids redundant DB queries)

--- a/abrg/internal/model/address.go
+++ b/abrg/internal/model/address.go
@@ -19,6 +19,9 @@ const (
 // All is a common constant representing "all" for various filters.
 const All = "all"
 
+// RsdtAddrFlgResidential is the rsdt_addr_flg value for 住居表示実施 (1).
+const RsdtAddrFlgResidential = "1"
+
 // MachiazaID constants
 const (
 	// UnknownMachiazaID represents an unknown machiaza (町字不明).


### PR DESCRIPTION
## 概要

Closes #262 — 住居表示マッチの rsdt_addr_flg が基底町字の値になる（混在地域で 0 が返る）

## 変更内容

`rsdt_addr_flg` の決定を以下のとおり整理した。

| ケース | 変更前 | 変更後 |
|---|---|---|
| 住居表示（rsdtdsp）マッチ | 基底町字の値（混在地域で `0`） | `1` 固定 |
| 町字マッチ・混在町字（flg 0/1 の2行） | ORDER BY 依存の行の値 | `null`（不明） |
| 町字マッチ・単一フラグ | その値 | 変更なし |

- 住居表示マッチ: cache_rsdtdsp は `rsdt_addr_flg = 1` の町字行からのみ構築される（createRsdtdspSQL）ため、住居表示マッチは構造上必ず実施側。定数 `1` を返す
- 町字マッチ: 混在町字は ABR 仕様上フラグごとに1行ずつ収録される（データフォーマット仕様確定版で rsdt_addr_flg は主キーの一部）。町字までのマッチではどちら側の住所か判定できないため `null` とする。v2 の `AMBIGUOUS_RSDT_ADDR_FLG = -1` と同じ整理
- 混在判定は jaccard 選択用に取得済みの候補内で行い、追加クエリなし

## 動作

| 入力 | 変更前 | 変更後 |
|---|---|---|
| 千葉県浦安市舞浜2-11 (rsdtdsp) | `"0"` | `"1"` |
| 兵庫県三田市三輪2-1-1 | `"0"` | `"1"` |
| 千葉県浦安市舞浜（町字マッチ・混在） | `"0"` | `null` |
| 北海道札幌市中央区南9条西5丁目（混在） | `"0"` | `null` |
| 東京都千代田区紀尾井町（単一フラグ） | `"1"` | `"1"` |
