### PR TITLE
perf(terraform): abrdbインポートタスクを8vCPU/16GBに適正化

### DIFF
--- a/docs/aws/terraform/modules/ecs/main.tf
+++ b/docs/aws/terraform/modules/ecs/main.tf
@@ -99,13 +99,13 @@ variable "abrg_memory_target" {
 variable "abrdb_cpu" {
   type        = string
   description = "CPU units for abrdb tasks (1024, 2048, 4096, 8192, 16384)"
-  default     = "16384" # 16 vCPU
+  default     = "8192" # 8 vCPU: import throughput is bound by Aurora writes, not CPU
 }
 
 variable "abrdb_memory" {
   type        = string
   description = "Memory (MB) for abrdb tasks"
-  default     = "32768" # 32 GB
+  default     = "16384" # 16 GB
 }
 
 variable "cache_build_cpu" {


### PR DESCRIPTION
## 概要

abrdb インポートタスク（Fargate）のデフォルトスペックを 16vCPU/32GB から 8vCPU/16GB に変更する。夜間データ更新の Fargate 費用が約半分になる。

## 背景

#263 の改善後、インポートのスループットは Aurora の書き込み側で律速されており、タスク CPU は余っている。全カテゴリ・全県・座標付きの満杯テーブルへの全件再インポート（約2.1億行）で確認した結果:

| スペック | 所要時間 |
|---|---|
| 16vCPU/32GB | 30分30秒 |
| 8vCPU/16GB | 12分53秒 |

8vCPU で所要時間の悪化はなく（環境要因でむしろ速い）、16GB メモリでの OOM も発生しない。定期実行（毎日02:00 JST）の時間枠にも十分収まる。