### PR TITLE
fix: add pigz to the AWS deployment image

### DIFF
--- a/abrg/Dockerfile
+++ b/abrg/Dockerfile
@@ -29,7 +29,6 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    pigz \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/abrg/abrg /app/abrg

--- a/docs/aws/abrg.Dockerfile
+++ b/docs/aws/abrg.Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     gzip \
+    pigz \
     curl \
     unzip \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## 概要

#269 で夜間 cache-build タスクのコマンドを `gzip` → `pigz` に切り替えたが、pigz パッケージを `abrg/Dockerfile`（開発用）にのみ追加していた。ECR にデプロイするイメージは `docs/aws/abrg.Dockerfile` からビルドされるため、BuildCache ステップが失敗する。デプロイ用 Dockerfile にも pigz を追加する。

修正イメージでの cache build → pigz 圧縮 → S3 アップロードの完走は確認済み。

## 関連

- #269