### PR TITLE
test: add fuzz targets for normalize and transform

### DIFF
--- a/abrg/internal/normalize/fuzz_test.go
+++ b/abrg/internal/normalize/fuzz_test.go
@@ -1,0 +1,102 @@
+package normalize
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzNFKCNormalize(f *testing.F) {
+	testCases := []string{
+		"東京都千代田区紀尾井町１−３",
+		"１２３４５",
+		"ＡＢＣａｂｃ",
+		"ｱｲｳｴｵ",
+		"test",
+		"",
+		"（１２３）－４５６",
+	}
+
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		out, _ := NFKCNormalize(s)
+		// If input is valid UTF-8, output must also be valid UTF-8
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Errorf("valid UTF-8 input produced invalid UTF-8 output: %q -> %q", s, out)
+		}
+	})
+}
+
+func FuzzNormalizeAddressText(f *testing.F) {
+	testCases := []string{
+		"東京都千代田区紀尾井町1番3号",
+		"東京都千代田区紀尾井町１番３号",
+		"東京都千代田区紀尾井町１－２－３",
+		"東京都千代田区紀尾井町1ー2ー3",
+		"",
+		"東京都",
+		"東京都千代田区紀尾井町1-2-3東京ガーデンテラス",
+	}
+
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		out, _ := NormalizeAddressText(s)
+		// If input is valid UTF-8, output must also be valid UTF-8
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Errorf("valid UTF-8 input produced invalid UTF-8 output: %q -> %q", s, out)
+		}
+	})
+}
+
+func FuzzNormalizeDashes(f *testing.F) {
+	testCases := []string{
+		"東京都千代田区紀尾井町",
+		"1-2-3",
+		"1－2－3",
+		"1–2–3",
+		"1—2—3",
+		"1ー2ー3",
+		"ガーデンテラス",
+		"",
+	}
+
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		out, _ := NormalizeDashes(s)
+		// If input is valid UTF-8, output must also be valid UTF-8
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Errorf("valid UTF-8 input produced invalid UTF-8 output: %q -> %q", s, out)
+		}
+	})
+}
+
+func FuzzNormalizeSpaces(f *testing.F) {
+	testCases := []string{
+		"  東京都港区三田  ",
+		"東京都　　港区　　　三田",
+		"東京都港区三田3-3-3",
+		"東京都\t\t港区\t\t\t三田",
+		"",
+		"   　　　   ",
+	}
+
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		out, _ := NormalizeSpaces(s)
+		// If input is valid UTF-8, output must also be valid UTF-8
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Errorf("valid UTF-8 input produced invalid UTF-8 output: %q -> %q", s, out)
+		}
+	})
+}

--- a/abrg/internal/transform/fuzz_test.go
+++ b/abrg/internal/transform/fuzz_test.go
@@ -1,0 +1,31 @@
+package transform
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzKanjiToArabic(f *testing.F) {
+	testCases := []string{
+		"一番地",
+		"二丁目",
+		"十番",
+		"零号〇番",
+		"一丁目二番三号",
+		"123-456",
+		"",
+		"壱弐参肆伍陸漆捌玖拾",
+	}
+
+	for _, tc := range testCases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		out, _ := KanjiToArabic(s)
+		// If input is valid UTF-8, output must also be valid UTF-8
+		if utf8.ValidString(s) && !utf8.ValidString(out) {
+			t.Errorf("valid UTF-8 input produced invalid UTF-8 output: %q -> %q", s, out)
+		}
+	})
+}


### PR DESCRIPTION
## 概要

normalize / transform の純関数に fuzz テストを追加する。

## 変更点

- normalize に FuzzNFKCNormalize / FuzzNormalizeAddressText / FuzzNormalizeDashes / FuzzNormalizeSpaces を追加
- transform に FuzzKanjiToArabic を追加
- シードは既存テーブルテストから転用。通常の `go test` ではシードのみ実行され、探索は `-fuzz` 指定時のみ行われる

## 挙動への影響

なし。テストのみの追加。
