### PR TITLE
docs(abrg): openapi の rsdt_addr_flg に値の意味を追記 (1/0/null)

### DIFF
--- a/abrg/openapi/openapi.yml
+++ b/abrg/openapi/openapi.yml
@@ -230,7 +230,12 @@ components:
         rsdt_addr_flg:
           type: string
           nullable: true
-          description: 住居表示フラグ
+          enum: ["1", "0", null]
+          description: |
+            住居表示フラグ。
+            - `1`: 住居表示実施
+            - `0`: 住居表示非実施
+            - `null`: match_level が machiaza または machiaza_detail で、実施・非実施のいずれか判定できない場合
           example: "1"
         blk_id:
           type: string


### PR DESCRIPTION
## 概要

`rsdt_addr_flg` の OpenAPI スキーマに、取りうる値とその意味を追記する。

## 変更内容

これまで description は「住居表示フラグ」のみで、`1` / `0` / `null` の意味が記載されていなかった。`enum` と各値の説明を追加する。

- `1`: 住居表示実施
- `0`: 住居表示非実施
- `null`: match_level が machiaza または machiaza_detail で、実施・非実施のいずれか判定できない場合

`null` は、実施区域・非実施区域が併存する町字（ABR 上フラグごとに1行ずつ収録される）に町字レベル・丁目/小字レベルでマッチした場合に返る。

ドキュメントのみの変更で、動作は変わらない。
