### PR TITLE
docs(abrg): record which string shape each aza-marker rule receives

### DIFF
--- a/abrg/internal/matching/levenshtein/unmatched.go
+++ b/abrg/internal/matching/levenshtein/unmatched.go
@@ -173,12 +173,16 @@ func extractUnmatchedSegments(originalAddr, matchedAddr string) []string {
 
 	// Post-process unmatchedSuffix
 	if unmatchedSuffix != "" {
-		// Strip "字" only when the unmatched suffix contains digits (aza + house/lot number).
-		// Preserve "字" when it's a standalone place name part with no numbers (sub-koaza name).
-		// e.g., "字東三分一1926-1" → "東三分一1926-1" (has digits, strip aza marker)
-		// e.g., "字堤下" → "字堤下" (no digits, preserve as place name)
-		// Note: Additional context-based stripping (e.g., when 大字 is present and koaza is unmatched)
-		// is handled by callers like extractUnmatchedAddress that have structured address info.
+		// unmatchedSuffix is a slice of the user input, so any lot number is still
+		// attached. A digit therefore means a lot number follows the koaza name,
+		// which makes the leading "字" a marker rather than part of the name.
+		// e.g., "字東三分一1926-1" → "東三分一1926-1"
+		// e.g., "字堤下" → "字堤下"
+		// unmatched.stripAzaMarker is the sibling rule for input without the lot number.
+		//
+		// Context-based stripping (e.g. when 大字 is present and koaza is unmatched)
+		// is handled by callers like extractUnmatchedAddress that have structured
+		// address info.
 		if strings.HasPrefix(unmatchedSuffix, "字") && strings.ContainsAny(unmatchedSuffix, "0123456789") {
 			unmatchedSuffix = strings.TrimPrefix(unmatchedSuffix, "字")
 		}

--- a/abrg/internal/matching/unmatched/unmatched.go
+++ b/abrg/internal/matching/unmatched/unmatched.go
@@ -120,9 +120,6 @@ func extractUnmatchedWithColon(originalAddr, standardizedAddrPart, matchedAddr, 
 	if after, found := strings.CutPrefix(standardizedAddrPart, matchedAddr); found && afterColon != "" {
 		trimmed := strings.TrimSuffix(after, afterColon)
 		if trimmed != "" && trimmed != after {
-			// Strip "字" when it's just a marker (字 alone) or when the koaza name
-			// ends with a kanji numeral (e.g., "字家六" → "家六", "字東三分一" → "東三分一").
-			// Preserve "字" when followed by a place name (e.g., "字上ノ原" stays).
 			trimmed = stripAzaMarker(trimmed)
 			if trimmed != "" {
 				unmatchedPrefix = trimmed
@@ -374,14 +371,21 @@ func extractUnmatchedFromStandardized(normalizedAddr, matchedAddr string) string
 	return ""
 }
 
-// stripAzaMarker strips the "字" (aza) prefix from unmatched address components
-// when it's just a marker rather than part of a meaningful place name.
+// stripAzaMarker strips the "字" (aza) prefix from an unmatched address component
+// when it is a marker rather than part of the place name.
+//
+// s is the koaza with the lot number already split off by the caller, so the
+// decision rests on the name alone.
 //
 // Strips "字" when:
-//   - s is exactly "字" (standalone marker)
-//   - the text after "字" ends with a kanji numeral (numbered koaza like "家六", "東三分一")
+//   - s is exactly "字", leaving nothing
+//   - the text after "字" ends with a kanji numeral, marking a numbered koaza
+//     where "字" introduces the number (e.g. "字家六" → "家六")
 //
-// Preserves "字" when the remaining text is a place name (e.g., "字上ノ原", "字堤下").
+// Preserves "字" when the remaining text is a place name (e.g. "字上ノ原", "字堤下").
+//
+// levenshtein.extractUnmatchedSegments is the sibling rule for input that still
+// carries the lot number, which is why it keys on digits instead.
 func stripAzaMarker(s string) string {
 	if !strings.HasPrefix(s, "字") {
 		return s


### PR DESCRIPTION
アンマッチ部分の先頭にある `字` を落とすかどうかを、2箇所が別々のルールで判定している。

| 箇所 | ルール |
|---|---|
| `levenshtein.extractUnmatchedSegments` | 断片が ASCII 数字を含むか |
| `unmatched.stripAzaMarker` | `字` の後ろの末尾 rune が漢数字か |

同じ判断の二重実装に見えるが、実際は受け取る文字列の形が違う。`extractUnmatchedSegments` は利用者の入力をそのまま切り出すので地番が付いたまま（`字東三分一1926-1`）で、`stripAzaMarker` は呼び出し側が地番を切り離した後（`字家六`）を受け取る。地番の有無という手がかりが片方にしかないため、それぞれ別の根拠で判定している。

従来のコメントはどちらも同じ `字東三分一` と `字堤下` を例に挙げるだけで、自分がどちらの形を受け取るかを書いていなかった。

## 変更

各コメントに、受け取る文字列の形とそれがルールの根拠になっていることを明記し、もう一方への参照を1行ずつ張った。

`stripAzaMarker` の呼び出し地点にあった説明は、関数の doc コメントが同じ契約を書いており、直上の `strings.TrimSuffix(after, afterColon)` が地番の切り離しを示しているため削除した。

コメントのみの変更で、実行時の挙動は変わらない。
