### PR TITLE
fix: npm publish が通るようにする

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,51 +18,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      #
-      # package.json に変化がなければ、node_modulesのキャッシュをrestoreする。
-      # jobが終了すると自動的にキャッシュされる
-      #
-      - uses: actions/cache@v4
-        name: Setup npm cache
-        id: node_modules
-        with:
-          path: |
-            node_modules/
-          key: ${{ github.head_ref }}-npm-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ github.head_ref }}-npm-${{ hashFiles('**/package.json') }}
-
-      #
-      # node_modules のキャッシュキーがヒットしていなければ
-      # package.json に従ってインストールする
-      #
       - name: Install dependencies
-        if: steps.node_modules.outputs.cache-hit != 'true'
         run: |
           npm install --global yarn
           yarn install
 
-      #
-      # src以下のファイルが変化していなければ、buildをrestoreする
-      #
-      - uses: actions/cache@v4
-        name: build_cache
-        id: build_cache
-        with:
-          path: |
-            build/
-          key: ${{ github.head_ref }}-build-${{ hashFiles('src/**/*.ts') }}
-          restore-keys: |
-            ${{ github.head_ref }}-build-${{ hashFiles('src/**/*.ts') }}
-
-      #
-      # ビルドのキャッシュがなければビルド
-      #
-      - name: Install dependencies
-        if: steps.build_cache.outputs.cache-hit != 'true'
-        run: |
-          npm run build
-
+      - name: Build
+        run: npm run build
 
       - name: Get the latest commit ID
         id: commit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,5 @@
-## This workflow has been disabled for now, because the CKAN API is blocking our requests.
-## Re-enable when we can package test data inside this repository.
+## npm への公開は手動実行のみ。ワークフローの実体はファイルパスで同一視されるため、
+## workflow_run で "tests" を待つと v3-beta の Go CI からも発火してしまう。
 
 name: "publish"
 
@@ -8,15 +8,10 @@ permissions:
   packages: read
 
 on:
-  workflow_run:
-    workflows: ["tests"]
-    types:
-      - completed
   workflow_dispatch:
 
 jobs:
   publish:
-    if: ${{ github.event.pull_request == null || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-## This workflow has been disabled for now, because the CKAN API is blocking our requests.
-## Re-enable when we can package test data inside this repository.
+## E2E テストは CKAN API がリクエストをブロックするため無効。
+## テストデータをリポジトリ内に同梱できるようになったら戻す。
 
 name: "tests"
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
     "target": "es2022",
     "module": "NodeNext",
     "strict": true,
+    // proj4 の型定義は optional peer の geotiff を参照する。geotiff を使わないので
+    // 依存の .d.ts は型検査の対象から外す。
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "sourceMap": true,
     "typeRoots": [


### PR DESCRIPTION
## tsconfig.json

`skipLibCheck` を有効にする。proj4 の型定義は optional peer dependency の geotiff を参照するが、geotiff は使っていないため未インストールで、依存の `.d.ts` の型検査が `TS2307` で失敗する。src の型検査と出力内容は変わらない。

## .github/workflows/cd.yml

publish のトリガを `workflow_dispatch` のみにする。ワークフローの実体はファイルパスで同一視されるため、`workflow_run` で "tests" の完了を待つと、同じ `.github/workflows/ci.yml` を使う v3-beta の Go CI からも発火する。

トリガが `workflow_dispatch` だけになり常に true となる `if:` 条件を削除する。

`node_modules/` と `build/` のキャッシュをやめて常にインストールとビルドを行う。`build/` のキャッシュキーは `src/**/*.ts` だけをハッシュしており、tsconfig や依存の変更ではキャッシュが無効化されず、古いビルド結果を公開しうる。実際にビルドしている step の名前を `Build` にする。

## .github/workflows/ci.yml

見出しコメントを実態に合わせる。このワークフローは有効で、無効なのはファイル内で個別にコメントアウトされている E2E テスト。