### PR TITLE
ci: publish のリリース作成を GITHUB_TOKEN で行う

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,20 +30,20 @@ jobs:
         id: commit
         run: echo "commit_id=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-      - name: create changelog.md
+      - name: Pack the tarball
         id: prepare
         run: |
           version=$(cat package.json | jq -r '.version')
           echo "version=$version" >> $GITHUB_OUTPUT
           tgz=$(npm pack | tail -n1 | tr -d '\n')
           echo "tgz=$tgz" >> $GITHUB_OUTPUT
-          
+
+      # npm への公開を先に行う。リリースを先に作ると、公開に失敗したときに
+      # タグとリリースだけが残る。
       - name: npm release
         run: |
-          npm publish . --dry-run
-          gh release create ${{ steps.prepare.outputs.version }}-${{ env.commit_id }} ${{ steps.prepare.outputs.tgz }}
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm publish . --access public
+          gh release create ${{ steps.prepare.outputs.version }}-${{ env.commit_id }} ${{ steps.prepare.outputs.tgz }}
         env:
-          GH_TOKEN: ${{ secrets.G_ACTIONS_TOKEN_FOR_PR }}
-          GITHUB_TOKEN: ${{ secrets.G_ACTIONS_TOKEN_FOR_PR }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`gh release create` に渡していた PAT `G_ACTIONS_TOKEN_FOR_PR` が失効していて HTTP 401 になる。このジョブは `permissions: contents: write` を持つため、組み込みの `GITHUB_TOKEN` でリリースを作成できる。

npm への公開をリリース作成より前に移す。リリースを先に作ると、公開に失敗したときにタグとリリースだけが残る。公開直前の `npm publish --dry-run` は本番の公開が先に来るため削除する。

tarball を作る step の名前が `create changelog.md` になっていたので実態に合わせる。