### PR TITLE
test(abrg): 回帰テストの issue 番号を実在するものに揃え、小字末尾の漢数字を扱うケースを追加

### DIFF
--- a/abrg/internal/matching/issues/issue290_test.go
+++ b/abrg/internal/matching/issues/issue290_test.go
@@ -1,0 +1,99 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue290 tests that a koaza ending with a kanji numeral followed by 字 stays intact.
+// Issue #290: 小字が漢数字+字で終わる住所で、完全一致でも数字がアンマッチとして返る
+// https://github.com/digital-go-jp/abr-geocoder/issues/290
+//
+// 問題:
+//   - 「字三字」のような小字は、末尾の「字」が単独の字マーカーとして除去され、
+//     残った漢数字が算用数字に変換されて地番として切り出される
+//   - 入力と matched_address が完全一致していても unmatched_address に数字が残る
+//   - 保護条件が unicode.IsDigit だったため、算用数字+字（「22字」）だけが保護されていた
+//
+// 解決:
+// - 漢数字と大字数字も保護対象に含め、小字名の一部として残す
+func TestIssue290(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		// 漢数字 + 字
+		{
+			name: "issue290-1 [愛知県名古屋市港区南陽町大字小川新田字三字]",
+			query: model.MatchQuery{
+				Address:  "愛知県名古屋市港区南陽町大字小川新田字三字",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "愛知県名古屋市港区南陽町大字小川新田字三字",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "愛知県",
+				FieldCity:    "名古屋市",
+				FieldWard:    "港区",
+				FieldOazaCho: "南陽町大字小川新田",
+				FieldKoaza:   "字三字",
+			},
+		},
+		{
+			name: "issue290-2 [山形県最上郡舟形町舟形字小田山外二字]",
+			query: model.MatchQuery{
+				Address:  "山形県最上郡舟形町舟形字小田山外二字",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "山形県最上郡舟形町舟形字小田山外二字",
+			wantUnmatchedAddress: nil,
+		},
+		{
+			name: "issue290-3 [石川県鳳珠郡能登町字柿生地七字]",
+			query: model.MatchQuery{
+				Address:  "石川県鳳珠郡能登町字柿生地七字",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県鳳珠郡能登町字柿生地七字",
+			wantUnmatchedAddress: nil,
+		},
+		// 大字数字 + 字は util.IsKanjiNumeral の対象外なので別に確認する
+		{
+			name: "issue290-4 [石川県加賀市横北町元矢田野村大字矢田野字七弐]",
+			query: model.MatchQuery{
+				Address:  "石川県加賀市横北町元矢田野村大字矢田野字七弐",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県加賀市横北町元矢田野村大字矢田野字七弐",
+			wantUnmatchedAddress: nil,
+		},
+		// 算用数字 + 字は元から保護されていた。regression テスト
+		{
+			name: "issue290-5 [福井県大野市犬山22字] 算用数字+字",
+			query: model.MatchQuery{
+				Address:  "福井県大野市犬山22字",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "福井県大野市犬山22字",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "福井県",
+				FieldCity:    "大野市",
+				FieldOazaCho: "犬山",
+				FieldKoaza:   "22字",
+			},
+		},
+	})
+}

--- a/abrg/internal/matching/issues/issue293_test.go
+++ b/abrg/internal/matching/issues/issue293_test.go
@@ -1,0 +1,110 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue293 tests that trailing digits belonging to a koaza name are not reported as unmatched.
+// Issue #293: 小字名が漢数字で終わる住所で、完全一致でも数字がアンマッチとして返る
+// https://github.com/digital-go-jp/abr-geocoder/issues/293
+//
+// 問題:
+//   - 「字女形二」のような小字は正規化で末尾が算用数字になり、その数字が地番として切り出される
+//   - 切り出した数字が小字名の一部かどうかを判定する matchesPlaceName は、
+//     小字名の全体を数字に変換したものと等値比較していた
+//   - 小字名の全体が数字の「壱九」は成立するが、名前の一部が数字の「字女形二」は
+//     「女形2 != 2」で不成立になり、数字がアンマッチとして残る
+//
+// 解決:
+// - 小字名の末尾から来た数字も小字名の一部として扱う
+func TestIssue293(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		// 小字名の一部が漢数字
+		{
+			name: "issue293-1 [宮城県石巻市広渕字女形二]",
+			query: model.MatchQuery{
+				Address:  "宮城県石巻市広渕字女形二",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "宮城県石巻市広渕字女形二",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "宮城県",
+				FieldCity:    "石巻市",
+				FieldOazaCho: "広渕",
+				FieldKoaza:   "字女形二",
+			},
+		},
+		{
+			name: "issue293-2 [宮城県石巻市北村字下田三]",
+			query: model.MatchQuery{
+				Address:  "宮城県石巻市北村字下田三",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "宮城県石巻市北村字下田三",
+			wantUnmatchedAddress: nil,
+		},
+		{
+			name: "issue293-3 [福島県伊達郡国見町大字藤田字沖ノ一]",
+			query: model.MatchQuery{
+				Address:  "福島県伊達郡国見町大字藤田字沖ノ一",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "福島県伊達郡国見町大字藤田字沖ノ一",
+			wantUnmatchedAddress: nil,
+		},
+		{
+			name: "issue293-4 [宮城県柴田郡村田町大字沼辺字東小沼二]",
+			query: model.MatchQuery{
+				Address:  "宮城県柴田郡村田町大字沼辺字東小沼二",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "宮城県柴田郡村田町大字沼辺字東小沼二",
+			wantUnmatchedAddress: nil,
+		},
+		// 小字名の全体が大字数字。元から成立していた。regression テスト
+		{
+			name: "issue293-5 [石川県七尾市能登島祖母ヶ浦町壱九] 小字全体が数字",
+			query: model.MatchQuery{
+				Address:  "石川県七尾市能登島祖母ヶ浦町壱九",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県七尾市能登島祖母ヶ浦町壱九",
+			wantUnmatchedAddress: nil,
+			wantStructured: map[string]any{
+				FieldPref:    "石川県",
+				FieldCity:    "七尾市",
+				FieldOazaCho: "能登島祖母ヶ浦町",
+				FieldKoaza:   "壱九",
+			},
+		},
+		{
+			name: "issue293-6 [石川県七尾市能登島鰀目町参八] 小字全体が数字",
+			query: model.MatchQuery{
+				Address:  "石川県七尾市能登島鰀目町参八",
+				Category: model.CategoryAll,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "石川県七尾市能登島鰀目町参八",
+			wantUnmatchedAddress: nil,
+		},
+	})
+}

--- a/abrg/internal/matching/issues/issue297_test.go
+++ b/abrg/internal/matching/issues/issue297_test.go
@@ -5,24 +5,25 @@ import (
 	"testing"
 )
 
-// TestIssue363 tests ward-only address resolution when prefecture and city are omitted.
-// Issue #363: 都道府県省略+同名区で正規化が完全マッチ失敗する
+// TestIssue297 tests ward-only address resolution when prefecture and city are omitted.
+// Issue #297: 都道府県と市名を省略した区名のみの住所が完全マッチしない
+// https://github.com/digital-go-jp/abr-geocoder/issues/297
 //
 // 問題:
 //   - 「中区本町1-1」のように都道府県と市名を省略し、区名のみで入力するとscore=-1で完全マッチ失敗
-//   - DB上のstandardized_addressは「横浜市中区本町」のようにcity+ward形式だが、
+//   - 照合列 normalized_address は「横浜市中区本町」のようにcity+ward形式だが、
 //     ユーザー入力は「中区本町」でward+oazaのみのため一致しない
-//   - cityPrefixMapは同名区(中区=4県)を除外するため、都道府県推定もできない
+//   - cityPrefixMapは複数県にまたがる区名を除外するため、都道府県推定もできない
 //
 // 解決:
 // - Ward展開フォールバック: 区名のみの入力を検出し、全候補市名を前置して再検索
 // - 「中区」→ [横浜市中区, 名古屋市中区, 広島市中区, 浜松市中区] で展開
-func TestIssue363(t *testing.T) {
+func TestIssue297(t *testing.T) {
 	runNormalizeTests(t, []normalizeTestCase{
 		// === Ward展開フォールバック ===
 		// 同名区「中区」: 横浜市/名古屋市/広島市/浜松市に存在
 		{
-			name: "issue363-1 [中区本町1-1] ward-only with ambiguous ward",
+			name: "issue297-1 [中区本町1-1] ward-only with ambiguous ward",
 			query: model.MatchQuery{
 				Address:  "中区本町1-1",
 				Category: model.CategoryBasic,
@@ -39,7 +40,7 @@ func TestIssue363(t *testing.T) {
 
 		// 同名区「南区」
 		{
-			name: "issue363-2 [南区白妙町1-1] ward-only",
+			name: "issue297-2 [南区白妙町1-1] ward-only",
 			query: model.MatchQuery{
 				Address:  "南区白妙町1-1",
 				Category: model.CategoryBasic,
@@ -56,7 +57,7 @@ func TestIssue363(t *testing.T) {
 		// 都道府県+市+区がすべて指定されている場合は既存フローで処理
 		{
 			// 本町1丁目が実在するため「1」を丁目として正しく解析
-			name: "issue363-3 [横浜市中区本町1-1] city+ward should still work",
+			name: "issue297-3 [横浜市中区本町1-1] city+ward should still work",
 			query: model.MatchQuery{
 				Address:  "横浜市中区本町1-1",
 				Category: model.CategoryBasic,
@@ -76,7 +77,7 @@ func TestIssue363(t *testing.T) {
 		},
 		{
 			// 本町1丁目が実在するため「1」を丁目として正しく解析
-			name: "issue363-4 [神奈川県横浜市中区本町1-1] full address",
+			name: "issue297-4 [神奈川県横浜市中区本町1-1] full address",
 			query: model.MatchQuery{
 				Address:  "神奈川県横浜市中区本町1-1",
 				Category: model.CategoryBasic,
@@ -97,7 +98,7 @@ func TestIssue363(t *testing.T) {
 
 		// 東京特別区は ward=NULL なので wardCandidates に含まれず既存フローで処理
 		{
-			name: "issue363-5 [中央区銀座1-1] Tokyo special ward unchanged",
+			name: "issue297-5 [中央区銀座1-1] Tokyo special ward unchanged",
 			query: model.MatchQuery{
 				Address:  "中央区銀座1-1",
 				Category: model.CategoryBasic,


### PR DESCRIPTION
## 概要

`internal/matching/issues` の回帰テストを 2 点整理する。テストのみの変更で、動作は変わらない。

## 実在しない issue 番号のリネーム

区名のみの住所を解決する ward 展開フォールバックのテストが `issue363_test.go` という名前だったが、このリポジトリに #363 は存在しない。同じ症状を記述した #297 に合わせて `issue297_test.go` にリネームし、テスト関数名とケース名も揃えた。

ヘッダコメントの照合列名が `standardized_address` になっていたのを実際の `normalized_address` に直し、「同名区を除外」という記述を `cityPrefixMap` の実際の挙動に合わせて「複数県にまたがる区名を除外」に改めた。

## 小字の末尾が漢数字になる住所のテスト追加

#290 と #293 は修正済みだが、テストは `internal/util` と `internal/matching/unmatched` の単体テストだけで、`match` を通した確認が無い。issue の再現例をそのままケースにした。

- `issue290_test.go` — 小字が漢数字 + 字 で終わる住所。`愛知県名古屋市港区南陽町大字小川新田字三字` など
- `issue293_test.go` — 小字名が漢数字で終わる住所。`宮城県石巻市広渕字女形二` など

いずれも修正前から成立していた形を regression ケースとして併せて入れている。#290 は算用数字 + 字 の `福井県大野市犬山22字`、#293 は小字名の全体が数字の `石川県七尾市能登島祖母ヶ浦町壱九`。#290 は大字数字が `util.IsKanjiNumeral` の対象外なので `字七弐` を別ケースにした。
