### PR TITLE
docs: イメージのビルド時期についての一文を削る

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,8 +38,6 @@ docker compose up -d abrg_app
 curl -s "http://localhost:3000/geocode?address=東京都千代田区紀尾井町1-3"
 ```
 
-イメージは必要になった時点でビルドされる。
-
 データは3つの named volume に残る。
 
 | Volume | 内容 |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ docker compose up -d abrg_app
 curl -s "http://localhost:3000/geocode?address=東京都千代田区紀尾井町1-3"
 ```
 
-The first command that needs an image builds it.
-
 Data persists in three named volumes.
 
 | Volume | Contents |


### PR DESCRIPTION
ルート README の全国データの手順にある「イメージは必要になった時点でビルドされる」を削る。

`docker compose build` というステップが無いことの説明であって、手順そのものの説明になっていない。上に並ぶコマンドを順に実行すれば動くので、Compose がいつイメージを作るかを読者が知る必要はない。