### PR TITLE
test(abrg): #295・#257 の回帰テストを追加

### DIFF
--- a/abrg/internal/matching/issues/issue257_test.go
+++ b/abrg/internal/matching/issues/issue257_test.go
@@ -1,0 +1,81 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue257 covers legacy address notation wrapped in an opening parenthesis
+// that is never closed. The trailing text matches no machiaza, so the city-level
+// result stands and the whole parenthesized part stays unmatched. A hang here
+// fails the test by exhausting the test binary timeout.
+// https://github.com/digital-go-jp/abr-geocoder/issues/257
+func TestIssue257(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		{
+			name: "issue257-1 [江東区（旧住所] unclosed parenthesis",
+			query: model.MatchQuery{
+				Address:  "東京都江東区（東京府南葛飾郡大島町大字中之郷出村３６番地",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelCity,
+			wantMatchedAddress:   "東京都江東区",
+			wantUnmatchedAddress: []string{"(東京府南葛飾郡大島町大字中之郷出村36番地"},
+			wantStructured: map[string]any{
+				FieldPref: "東京都",
+				FieldCity: "江東区",
+			},
+		},
+		{
+			name: "issue257-2 [江東区（旧住所）] closed parenthesis",
+			query: model.MatchQuery{
+				Address:  "東京都江東区（東京府南葛飾郡大島町大字中之郷出村３６番地）",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelCity,
+			wantMatchedAddress:   "東京都江東区",
+			wantUnmatchedAddress: []string{"(東京府南葛飾郡大島町大字中之郷出村36番地)"},
+			wantStructured: map[string]any{
+				FieldPref: "東京都",
+				FieldCity: "江東区",
+			},
+		},
+		{
+			name: "issue257-3 [江東区（（（旧住所] repeated opening parentheses",
+			query: model.MatchQuery{
+				Address:  "東京都江東区（（（東京府南葛飾郡大島町大字中之郷出村３６番地",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelCity,
+			wantMatchedAddress:   "東京都江東区",
+			wantUnmatchedAddress: []string{"(", "(", "(東京府南葛飾郡大島町大字中之郷出村36番地"},
+			wantStructured: map[string]any{
+				FieldPref: "東京都",
+				FieldCity: "江東区",
+			},
+		},
+		{
+			// A normal address in the same city must keep matching past city level.
+			name: "issue257-4 [江東区亀戸2-22-17] unaffected address",
+			query: model.MatchQuery{
+				Address:  "東京都江東区亀戸2-22-17",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "東京都江東区亀戸2丁目",
+			wantUnmatchedAddress: []string{"22-17"},
+			wantStructured: map[string]any{
+				FieldOazaCho: "亀戸",
+				FieldChome:   "2丁目",
+			},
+		},
+	})
+}

--- a/abrg/internal/matching/issues/issue295_test.go
+++ b/abrg/internal/matching/issues/issue295_test.go
@@ -1,0 +1,102 @@
+package issues
+
+import (
+	"abrg/internal/model"
+	"testing"
+)
+
+// TestIssue295 covers chome input on machiaza whose own name ends in a numeral
+// word (一番町, 二番町). The chome marker has to be consumed by the chome match
+// instead of being left in the unmatched remainder, where it would be reported
+// on top of the already normalized chome.
+// https://github.com/digital-go-jp/abr-geocoder/issues/295
+func TestIssue295(t *testing.T) {
+	runNormalizeTests(t, []normalizeTestCase{
+		{
+			name: "issue295-1 [松山市一番町4丁目4-2] chome marker consumed",
+			query: model.MatchQuery{
+				Address:  "愛媛県松山市一番町4丁目4-2",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "愛媛県松山市一番町四丁目",
+			wantUnmatchedAddress: []string{"4-2"},
+			wantStructured: map[string]any{
+				FieldPref:    "愛媛県",
+				FieldCity:    "松山市",
+				FieldOazaCho: "一番町",
+				FieldChome:   "四丁目",
+			},
+		},
+		{
+			// The data spells this chome with an Arabic numeral, unlike 松山市.
+			name: "issue295-2 [仙台市青葉区一番町1丁目9-1] chome marker consumed",
+			query: model.MatchQuery{
+				Address:  "宮城県仙台市青葉区一番町1丁目9-1",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "宮城県仙台市青葉区一番町1丁目",
+			wantUnmatchedAddress: []string{"9-1"},
+			wantStructured: map[string]any{
+				FieldPref:    "宮城県",
+				FieldCity:    "仙台市",
+				FieldWard:    "青葉区",
+				FieldOazaCho: "一番町",
+				FieldChome:   "1丁目",
+			},
+		},
+		{
+			name: "issue295-3 [松山市二番町4丁目1-1] chome marker consumed",
+			query: model.MatchQuery{
+				Address:  "愛媛県松山市二番町4丁目1-1",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "愛媛県松山市二番町四丁目",
+			wantUnmatchedAddress: []string{"1-1"},
+			wantStructured: map[string]any{
+				FieldOazaCho: "二番町",
+				FieldChome:   "四丁目",
+			},
+		},
+		{
+			name: "issue295-4 [松山市一番町４丁目４－２] full-width input",
+			query: model.MatchQuery{
+				Address:  "愛媛県松山市一番町４丁目４－２",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "愛媛県松山市一番町四丁目",
+			wantUnmatchedAddress: []string{"4-2"},
+			wantStructured: map[string]any{
+				FieldOazaCho: "一番町",
+				FieldChome:   "四丁目",
+			},
+		},
+		{
+			name: "issue295-5 [松山市一番町4丁目4番2号] ban-go notation",
+			query: model.MatchQuery{
+				Address:  "愛媛県松山市一番町4丁目4番2号",
+				Category: model.CategoryBasic,
+				Pref:     "all",
+				Limit:    1,
+			},
+			wantMatchLevel:       model.MatchLevelMachiazaDetail,
+			wantMatchedAddress:   "愛媛県松山市一番町四丁目",
+			wantUnmatchedAddress: []string{"4-2"},
+			wantStructured: map[string]any{
+				FieldOazaCho: "一番町",
+				FieldChome:   "四丁目",
+			},
+		},
+	})
+}


### PR DESCRIPTION
v2 で報告された 2 件について、v3 での挙動を固定する回帰テストを `internal/matching/issues/` に追加する。どちらも v3 では現状すでに期待どおりの結果を返す。

## #295 町名末尾が数詞の町字に丁目を付けた入力

「一番町4丁目」のように町名自体が数詞で終わる町字へ丁目を付けると、v2 では丁目マーカーが未マッチの残りに残り、正規化済みの丁目表記に重ねて「四丁目丁目」と出力される。丁目マーカーが丁目マッチで消費され、未マッチ側に残らないことを検証する。

- 松山市一番町4丁目4-2 → `愛媛県松山市一番町四丁目` + 未マッチ `["4-2"]`
- 仙台市青葉区一番町1丁目9-1 → `宮城県仙台市青葉区一番町1丁目` + 未マッチ `["9-1"]`
- 松山市二番町、全角表記、「N番M号」表記

## #257 閉じない開き括弧を含む旧住所表記

`東京都江東区（東京府南葛飾郡大島町大字中之郷出村３６番地` のように開き括弧が閉じない入力で、v2 は処理が返らなくなる。市区町村レベルで止まり、括弧以降が丸ごと未マッチとして返ることを検証する。処理が返らなくなればテストバイナリのタイムアウトで落ちる。

- 閉じ括弧なし・閉じ括弧あり・開き括弧 3 連続
- 対照として同一市区町村の通常の住所

## 補足

いずれも `CategoryBasic` で問い合わせる。丁目の消費も括弧の扱いも basic 層で決まり、parcel・rsdtdsp を含めるとデータ更新でマッチレベルが揺れるため。他の issues テストと同じくキャッシュ依存で、`CACHE_PATH` がなければ skip される。

テストのみの変更のため VERSION は変更しない。