### PR TITLE
chore(ci): アクションを更新し、govulncheck の失敗でCIを止める

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: pr
       - name: Checkout base
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,8 +19,8 @@ jobs:
       matrix:
         module: [abrg, abrdb, common]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true
@@ -54,8 +58,8 @@ jobs:
       DB_NAME: abrdb
       DB_SSLMODE: disable
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true
@@ -68,8 +72,8 @@ jobs:
       matrix:
         module: [abrg, abrdb, common]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true
@@ -85,13 +89,12 @@ jobs:
 
   vuln:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         module: [abrg, abrdb, common]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true
@@ -105,8 +108,8 @@ jobs:
   vuln-version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,13 +13,17 @@ permissions:
   security-events: write
   actions: read
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (Go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.x'
           cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
   compose:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Write .env
         run: sed 's/^DB_PASSWORD=$/DB_PASSWORD=postgres/' .env.example > .env


### PR DESCRIPTION
## アクションの更新

`actions/checkout` と `actions/setup-go` をいずれも v6 から v7 に上げる。

本来 dependabot が運ぶ変更だが、`.github/dependabot.yml` はこのブランチにしか存在しない。dependabot は設定を既定ブランチからのみ読むため、現在は一度も動いておらず PR も0件になっている。v3-beta が既定ブランチになれば解消するので、それまでの分を手で上げる。

同じ理由で、`codeql.yml` に書かれた週次の `schedule` も発火していない。全 462 回の実行のうち `schedule` 起因は0件。こちらもブランチが切り替われば動き出す。

## govulncheck

`vuln` ジョブから `continue-on-error: true` を外す。

govulncheck が非ゼロで終わるのは、自分のコードが実際に呼び出している脆弱性がある場合だけで、require しているモジュールに存在するだけなら通過する。巻き添えでCIが止まる性質のものではなく、失敗したときは対処が要る。現状は3モジュールとも `No vulnerabilities found.` で通る。

## concurrency

`ci.yml` と `codeql.yml` に、`docker.yml` と `bench.yml` が既に持っている concurrency グループを入れる。打ち切るのは pull request の実行だけで、追跡ブランチへの push は最後まで走らせる。