### PR TITLE
docs(abrg): コメントから以前の実装との対比を取り除く

### DIFF
--- a/abrg/internal/matching/detect_prefecture.go
+++ b/abrg/internal/matching/detect_prefecture.go
@@ -65,9 +65,9 @@ func buildPrefectureByCode() map[string]string {
 }
 
 // detectPrefectureCode detects prefecture code from address string.
-// Every prefecture name is either 3 runes (9 bytes) or 4 runes (12 bytes) and
-// no short name is a prefix of a long one, so probing those two lengths
-// longest-first is equivalent to scanning all 47 entries.
+// Every prefecture name is either 3 runes (9 bytes) or 4 runes (12 bytes), and
+// no short name is a prefix of a long one, so at most one name can match and
+// probing those two lengths longest-first finds it.
 func detectPrefectureCode(address string) string {
 	for _, n := range [2]int{12, 9} {
 		if len(address) < n {

--- a/abrg/internal/repository/spatial.go
+++ b/abrg/internal/repository/spatial.go
@@ -24,15 +24,15 @@ func prefFilter(alias, pref string) (string, error) {
 
 // Every reverse query orders by distance and then by lg_code and machiaza_id.
 // The tie-break is what makes the result reproducible: several machiaza can sit
-// on one coordinate (Kyoto street names, for one), and ordering by distance
-// alone leaves the parallel scan to decide which of the tied rows LIMIT keeps,
-// so the same query returned different rows from run to run.
+// on one coordinate (Kyoto street names, for one), and with distance as the only
+// key the parallel scan decides which of the tied rows LIMIT keeps, so the same
+// coordinate can answer with a different address on each run.
 //
 // For cache_machiaza that pair is the primary key, so the order is total. For
 // the detail tables it orders down to the machiaza only; adding the rows' own
 // ids would make it total there too, but sorting the candidate set on those
-// high-cardinality columns costs several times the query time, and the ties
-// left unresolved are between detail rows of a single machiaza.
+// high-cardinality columns costs several times the query time, and the ties it
+// would resolve are between detail rows of a single machiaza.
 
 // reverseAddrColumns are the address columns every reverse result carries, in
 // the order reverseBaseScan.appendAddrPtrs scans them. They always come from

--- a/abrg/internal/util/city_boundary.go
+++ b/abrg/internal/util/city_boundary.go
@@ -36,8 +36,8 @@ func NewCityBoundary(cityStrings []string) *CityBoundary {
 // heuristic, preserving behavior for ward-only and prefecture-prefixed inputs.
 func (b *CityBoundary) Find(addr string) int {
 	if b != nil && len(b.set) > 0 {
-		// Probe by byte offset rather than slicing a []rune: substrings of addr
-		// share its backing array, so no candidate prefix is allocated.
+		// Probe by byte offset: a substring of addr shares its backing array, so
+		// no candidate prefix is allocated.
 		end := len(addr)
 		if utf8.RuneCountInString(addr) > b.maxRunes {
 			end = 0


### PR DESCRIPTION
コメント 3 箇所が、置き換える前の実装との対比でコードを説明していた。初見の読者にはその前提が無いため、それぞれ不変条件そのものか、防いでいる失敗を単体で述べる形に直す。

- `detectPrefectureCode` — 「47 件を走査するのと等価」ではなく、都道府県名が 3 runes か 4 runes で短い側が長い側の接頭辞にならないため一致し得るのは最大 1 件、という不変条件を述べる
- `CityBoundary.Find` — 「`[]rune` を切るのではなく」を外し、addr の部分文字列が同じ backing array を共有するため候補接頭辞を確保しないこと自体を述べる
- 逆ジオコーディングの並び順 — 「実行ごとに違う行を返していた」という過去形をやめ、distance だけを key にすると同順位のどれを LIMIT が残すか並列スキャンが決めるため、同じ座標が実行ごとに違う住所を返し得る、と現在の性質として述べる

コメントのみの変更で、コードは変わらない。
