### PR TITLE
docs(abrg): score の定義を実装に合わせる

### DIFF
--- a/abrg/openapi/openapi.yml
+++ b/abrg/openapi/openapi.yml
@@ -521,9 +521,11 @@ components:
                         score:
                           type: number
                           format: double
-                          minimum: 0
+                          minimum: -1
                           maximum: 1
-                          description: マッチスコア（参考値）
+                          description: |
+                            候補の並べ替えに使う参考値。match_level が unknown のときは -1。
+                            マッチの正しさは表さないため、採否の判断には使わないでください。
                           example: 1
                         match_level:
                           allOf:
@@ -564,7 +566,7 @@ components:
                     properties:
                       matched_address: "東京都千代田区紀尾井町1-3"
                       unmatched_address: ["東京ガーデンテラス紀尾井町", "19階、20階"]
-                      score: 0.8
+                      score: 1
                       match_level: "rsdtdsp_rsdt"
                       coordinates_level: "rsdtdsp_rsdt"
                       ids:
@@ -598,7 +600,7 @@ components:
                     properties:
                       matched_address: "東京都千代田区紀尾井町"
                       unmatched_address: null
-                      score: 0.6
+                      score: 1
                       match_level: "machiaza"
                       coordinates_level: "machiaza"
                       ids:
@@ -842,9 +844,11 @@ components:
                     score:
                       type: number
                       format: double
-                      minimum: 0
+                      minimum: -1
                       maximum: 1
-                      description: マッチスコア（参考値）
+                      description: |
+                        候補の並べ替えに使う参考値。match_level が unknown のときは -1。
+                        マッチの正しさは表さないため、採否の判断には使わないでください。
                       example: 1
                     ids:
                       $ref: "#/components/schemas/Ids"
@@ -874,7 +878,7 @@ components:
                       - "東京ガーデンテラス紀尾井町"
                       - "19階、20階"
                     match_level: "rsdtdsp_rsdt"
-                    score: 0.8
+                    score: 1
                     ids:
                       lg_code: "131016"
                       machiaza_id: "0056000"
@@ -902,7 +906,7 @@ components:
                   - matched_address: "東京都千代田区紀尾井町"
                     unmatched_address: null
                     match_level: "machiaza"
-                    score: 0.6
+                    score: 1
                     ids:
                       lg_code: "131016"
                       machiaza_id: "0056000"


### PR DESCRIPTION
## 変更

`openapi.yml` の `score` の定義を実装に合わせる。

- `minimum` を `0` から `-1` に変更。マッチするレコードがない場合（`match_level` が `unknown`）に `-1` を返すため
- `description` を差し替え。候補の並べ替えに使う参考値であり、マッチの正しさは表さないため採否の判断には使わない旨を明記
- レスポンス例の `score` を `0.8` / `0.6` から `1` に修正。建物名が `unmatched_address` に残る例も、町字止まりの例も実際には `1` になる

`geocodeOk` と `matchOk` の両方に同じ内容を適用している。

ドキュメントのみの変更のため VERSION は据え置き。