### PR TITLE
fix: town_pos の取り込みで city_key を行ごとに求める (#329)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,9 @@
-const { compilerOptions } = require('./tsconfig.json')
+const ts = require('typescript')
 const { pathsToModuleNameMapper } = require('ts-jest')
+
+// tsconfig.json holds comments, which JSON.parse rejects. Read it with the
+// compiler's own parser instead of require().
+const { compilerOptions } = ts.readConfigFile('./tsconfig.json', ts.sys.readFile).config
 
 const targetTestFile = process.argv[2];
 const { roots, moduleDirectories } = (() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-go-jp/abr-geocoder",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "デジタル庁：アドレス・ベース・レジストリを用いたジオコーダー",
   "author": "Japan Digital Agency (デジタル庁)",
   "keywords": [

--- a/src/drivers/database/sqlite3/download/__tests__/common-db-download-sqlite3.test.ts
+++ b/src/drivers/database/sqlite3/download/__tests__/common-db-download-sqlite3.test.ts
@@ -1,0 +1,65 @@
+import { DbTableName } from '@config/db-table-name';
+import { TableKeyProvider } from '@domain/services/table-key-provider';
+import { describe, expect, it } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CommonDbDownloadSqlite3 } from '../common-db-download-sqlite3';
+
+const openDb = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'abrg-db-'));
+  return new CommonDbDownloadSqlite3({
+    sqliteFilePath: path.join(dir, 'common.sqlite'),
+    readonly: false,
+  });
+};
+
+describe('CommonDbDownloadSqlite3', () => {
+  // mt_town_pos_pref** covers a whole prefecture, so one batch holds rows of
+  // several municipalities. Each row must keep the city of its own lg_code.
+  it('assigns city_key per row when town_pos rows span municipalities', async () => {
+    const db = openDb();
+    await db.townPosCsvRows([
+      { lg_code: '131016', machiaza_id: '0056000', rep_lat: '35.679107', rep_lon: '139.736394' },
+      { lg_code: '132012', machiaza_id: '0123000', rep_lat: '35.683015', rep_lon: '139.348861' },
+    ]);
+
+    const rows = (db as unknown as {
+      driver: { prepare: (sql: string) => { all: () => Record<string, number>[] } };
+    }).driver
+      .prepare(`SELECT town_key, city_key FROM ${DbTableName.TOWN} ORDER BY town_key`)
+      .all();
+
+    const cityKeyOf = (lgCode: string) => TableKeyProvider.getCityKey({ lg_code: lgCode });
+    const townKeyOf = (lgCode: string, machiazaId: string) =>
+      TableKeyProvider.getTownKey({ lg_code: lgCode, machiaza_id: machiazaId });
+
+    expect(rows).toHaveLength(2);
+    expect(new Map(rows.map(row => [row.town_key, row.city_key]))).toEqual(
+      new Map([
+        [townKeyOf('131016', '0056000'), cityKeyOf('131016')],
+        [townKeyOf('132012', '0123000'), cityKeyOf('132012')],
+      ]),
+    );
+    await db.close();
+  });
+
+  it('keeps city_key per row for town rows', async () => {
+    const db = openDb();
+    await db.townCsvRows([
+      {
+        lg_code: '131016', machiaza_id: '0056000', oaza_cho: '紀尾井町', chome: '',
+        koaza: '', rsdt_addr_flg: 1, koaza_aka_code: 0, machiaza_dist: '', crc32: 0,
+      },
+    ]);
+
+    const row = (db as unknown as {
+      driver: { prepare: (sql: string) => { get: () => Record<string, number> } };
+    }).driver
+      .prepare(`SELECT city_key FROM ${DbTableName.TOWN}`)
+      .get();
+
+    expect(row.city_key).toBe(TableKeyProvider.getCityKey({ lg_code: '131016' }));
+    await db.close();
+  });
+});

--- a/src/drivers/database/sqlite3/download/__tests__/common-db-download-sqlite3.test.ts
+++ b/src/drivers/database/sqlite3/download/__tests__/common-db-download-sqlite3.test.ts
@@ -44,6 +44,34 @@ describe('CommonDbDownloadSqlite3', () => {
     await db.close();
   });
 
+  // A database built before the per-row fix holds towns under the wrong city.
+  // Downloading again must move them back instead of leaving them stranded.
+  it('repairs a wrong city_key on re-import', async () => {
+    const db = openDb();
+    const townRow = {
+      lg_code: '271209', machiaza_id: '0025003', oaza_cho: '南住吉', chome: '三丁目',
+      koaza: '', rsdt_addr_flg: 1, koaza_aka_code: 0, machiaza_dist: '', crc32: 1,
+    };
+    await db.townCsvRows([townRow]);
+
+    const driver = (db as unknown as {
+      driver: {
+        prepare: (sql: string) => { run: (...args: unknown[]) => void; get: () => Record<string, number> };
+      };
+    }).driver;
+    const wrongCityKey = TableKeyProvider.getCityKey({ lg_code: '271021' });
+    driver.prepare(`UPDATE ${DbTableName.TOWN} SET city_key = ?`).run(wrongCityKey);
+
+    await db.townCsvRows([townRow]);
+    await db.townPosCsvRows([
+      { lg_code: '271209', machiaza_id: '0025003', rep_lat: '34.604514', rep_lon: '135.500015' },
+    ]);
+
+    const row = driver.prepare(`SELECT city_key FROM ${DbTableName.TOWN}`).get();
+    expect(row.city_key).toBe(TableKeyProvider.getCityKey({ lg_code: '271209' }));
+    await db.close();
+  });
+
   it('keeps city_key per row for town rows', async () => {
     const db = openDb();
     await db.townCsvRows([

--- a/src/drivers/database/sqlite3/download/common-db-download-sqlite3.ts
+++ b/src/drivers/database/sqlite3/download/common-db-download-sqlite3.ts
@@ -282,11 +282,7 @@ export class CommonDbDownloadSqlite3
         crc32 IS NULL
     `;
     await this.createTownTable();
-    const cityKey = TableKeyProvider.getCityKey({
-      lg_code: rows[0][DataField.LG_CODE.dbColumn].toString(),
-    });
     return await this.upsertRowsForTown({
-      cityKey,
       upsert: this.prepare(sql),
       rows,
     });
@@ -318,25 +314,24 @@ export class CommonDbDownloadSqlite3
     `;
     await this.createTownTable();
 
-    const cityKey = TableKeyProvider.getCityKey({
-      lg_code: rows[0][DataField.LG_CODE.dbColumn].toString(),
-    });
     return await this.upsertRowsForTown({
-      cityKey,
       upsert: this.prepare(sql),
       rows,
     });
   }
 
+  // mt_town_pos_pref** は都道府県単位のファイルなので、1バッチに複数の市区町村が
+  // 混ざる。city_key は行ごとに、その行の lg_code から求める。
   private async upsertRowsForTown(params: Required<{
     upsert: Statement;
-    cityKey: number;
     rows: Record<string, string | number>[];
   }>) {
     return await new Promise((resolve: (_?: void) => void) => {
       this.driver.transaction((rows: Record<string, string | number>[]) => {
         for (const row of rows) {
-          row.city_key = params.cityKey;
+          row.city_key = TableKeyProvider.getCityKey({
+            lg_code: row[DataField.LG_CODE.dbColumn] as string,
+          });
           row.town_key = TableKeyProvider.getTownKey({
             lg_code: row[DataField.LG_CODE.dbColumn] as string,
             machiaza_id: row[DataField.MACHIAZA_ID.dbColumn] as string,

--- a/src/drivers/database/sqlite3/download/common-db-download-sqlite3.ts
+++ b/src/drivers/database/sqlite3/download/common-db-download-sqlite3.ts
@@ -270,6 +270,7 @@ export class CommonDbDownloadSqlite3
         @koaza_aka_code,
         @crc32
       ) ON CONFLICT (town_key) DO UPDATE SET
+        city_key = @city_key,
         ${DataField.MACHIAZA_ID.dbColumn} = @machiaza_id,
         ${DataField.OAZA_CHO.dbColumn} = @oaza_cho,
         ${DataField.CHOME.dbColumn} = @chome,
@@ -279,7 +280,8 @@ export class CommonDbDownloadSqlite3
         crc32 = @crc32
       WHERE
         crc32 != @crc32 OR
-        crc32 IS NULL
+        crc32 IS NULL OR
+        city_key != @city_key
     `;
     await this.createTownTable();
     return await this.upsertRowsForTown({
@@ -304,13 +306,15 @@ export class CommonDbDownloadSqlite3
         @rep_lat,
         @rep_lon
       ) ON CONFLICT (town_key) DO UPDATE SET
+        city_key = @city_key,
         ${DataField.REP_LAT.dbColumn} = @rep_lat,
         ${DataField.REP_LON.dbColumn} = @rep_lon
-      WHERE 
-        ${DataField.REP_LAT.dbColumn} != @rep_lat OR 
-        ${DataField.REP_LON.dbColumn} != @rep_lon OR 
+      WHERE
+        ${DataField.REP_LAT.dbColumn} != @rep_lat OR
+        ${DataField.REP_LON.dbColumn} != @rep_lon OR
         ${DataField.REP_LAT.dbColumn} IS NULL OR
-        ${DataField.REP_LON.dbColumn} IS NULL
+        ${DataField.REP_LON.dbColumn} IS NULL OR
+        city_key != @city_key
     `;
     await this.createTownTable();
 

--- a/src/usecases/download/steps/csv-load-step1-transform.ts
+++ b/src/usecases/download/steps/csv-load-step1-transform.ts
@@ -129,7 +129,7 @@ export class CsvLoadStep1Transform extends Duplex {
       };
 
       case 'town_pos': {
-        return new TownPosDatasetFile(params);
+        return new TownPosDatasetFile(datasetParams);
       }
 
       case 'rsdtdsp_blk': {


### PR DESCRIPTION
#329

## 概要

都道府県単位で配信される `mt_town_pos_pref**` を取り込むと、`town` テーブルの `city_key` がバッチ先頭行の市区町村に固定され、町字が別の市区町村に紐づく。その市区町村では `city` から `town` を辿れず、ジオコーディングが `match_level=city` で止まる。

## 原因

`upsertRowsForTown` が `rows[0]` の `lg_code` から `city_key` を一度だけ求め、バッチの全行に適用していた。市区町村単位のファイルは全行の `lg_code` が同じなので表面化しないが、都道府県単位のファイルでは先頭行以外がすべて誤る。

## 変更

- `city_key` を行ごとに、その行の `lg_code` から求める
- `ON CONFLICT DO UPDATE` で `city_key` も書き、値が違うことを更新条件に加える。2.3.0 で作ったデータベースは名称と座標のカラムしか更新されないため、再取得しても誤った `city_key` が残る
- `town_pos` にも `lgCodeFilter` を渡し、他の12のデータセットと揃える
- `jest.config.js` が `tsconfig.json` を `require` で読んでいる。現在の `tsconfig.json` はコメントを含むため `JSON.parse` が失敗し、テストが1件も起動しない。TypeScript のパーサで読むようにする

## 追加したテスト

- 複数の市区町村をまたぐ `town_pos` のバッチで、`city_key` が行ごとに付くこと
- 誤った `city_key` を持つ既存データが、再取り込みで正しい値に直ること
- 市区町村単位のファイルでは従来どおりの `city_key` が付くこと

## 確認したこと

- #329 に挙がっている大阪府大阪市住吉区南住吉3-15-55 が `residential_detail`（lat 34.604514498 / lon 135.500015296）まで解決する
- 東京都62市区町村を取得すると、`town` は 6,359 行すべてが一意になり、62市区町村に分かれる。修正前は一意 1,641 行・30市区町村だった
- 全国を取得すると 854,339 行が 1,898 市区町村に分かれる。大阪市都島区は 47 件、住吉区は 104 件
- テスト 141 件が通る