### PR TITLE
データ更新ワークフローに強制実行の入力を追加する

### DIFF
--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -439,13 +439,21 @@ aws ecs run-task --cluster $ECS_CLUSTER --task-definition abrdb-import --launch-
 
 キャッシュは稼働中バイナリと組で整合している必要があります。スキーマ版と正規化のどちらが食い違っても起動を拒否されるため、イメージとキャッシュは同じ世代の組に戻します。
 
-タスク定義は `:latest` を参照するので、旧バージョンタグを `:latest` に付け替えた上で、S3 のバージョニングから1世代前のキャッシュに戻します。整合した組に戻るため、キャッシュの再構築を待たずに復旧できます。
+タスク定義は `:latest` を参照するので、旧バージョンタグを `:latest` に付け替えた上で、戻す先のイメージが作ったキャッシュに戻します。整合した組に戻るため、キャッシュの再構築を待たずに復旧できます。
+
+戻す先は**単純に1世代前ではありません**。戻したいリリースの後に日次実行や手動実行でキャッシュが作り直されていると、直前の世代も新しいイメージが作ったものです。**リリースより前に作られた最新のキャッシュ**を、`LastModified` を見て選びます。
 
 ```bash
 # 旧バージョンを latest に付け替える（例: 3.0.40 へ戻す）
 MANIFEST=$(aws ecr batch-get-image --repository-name abrg \
   --image-ids imageTag=3.0.40 --query 'images[0].imageManifest' --output text)
 aws ecr put-image --repository-name abrg --image-tag latest --image-manifest "$MANIFEST"
+
+# 戻す先のイメージが push された時刻を調べ、それより前の最新のキャッシュを選ぶ
+aws ecr describe-images --repository-name abrg \
+  --image-ids imageTag=3.0.40 --query 'imageDetails[0].imagePushedAt' --output text
+aws s3api list-object-versions --bucket $(terraform output -raw cache_bucket) \
+  --prefix abrg/abrg.duckdb.gz --query 'sort_by(Versions,&LastModified)[].[LastModified,VersionId]' --output text
 ```
 
 S3 のキャッシュは非現行バージョンを30日で失効させるため、それより前には戻せません。その場合は現行バイナリで `cache build` し直してください。

--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -203,14 +203,20 @@ aws ecr get-login-password | \
 docker build --platform linux/arm64 -f abrg/Dockerfile \
   --build-arg COMMIT=$(git rev-parse --short HEAD) -t abrg .
 docker tag abrg:latest $ABRG_REPO:latest
+docker tag abrg:latest $ABRG_REPO:$(cat abrg/VERSION)
 docker push $ABRG_REPO:latest
+docker push $ABRG_REPO:$(cat abrg/VERSION)
 
 # abrdb
 docker build --platform linux/arm64 -f abrdb/Dockerfile \
   --build-arg COMMIT=$(git rev-parse --short HEAD) -t abrdb .
 docker tag abrdb:latest $ABRDB_REPO:latest
+docker tag abrdb:latest $ABRDB_REPO:$(cat abrdb/VERSION)
 docker push $ABRDB_REPO:latest
+docker push $ABRDB_REPO:$(cat abrdb/VERSION)
 ```
+
+タスク定義は `:latest` を参照します。バージョンタグは戻し先を残すために併せて push します。`:latest` だけだと、旧イメージへ戻す手段がタグのないダイジェスト探しになり、ECR の保持世代を超えると失われます。
 
 ### データベース初期化
 
@@ -331,19 +337,26 @@ EventBridge Scheduler が毎日 02:00 JST に Step Functions を実行します�
 ```mermaid
 flowchart TD
     EB["EventBridge Scheduler<br/>毎日 02:00 JST"] --> SFN["Step Functions"]
-    SFN --> CHECK["CheckChanges<br/>(import --dry-run)"]
+    MAN["手動実行"] --> SFN
+    SFN --> ROUTE{"Route<br/>(実行入力)"}
+    ROUTE -->|rebuild_cache_only| CACHE
+    ROUTE -->|force| FORCE["ForceImport<br/>(import --force --quiet)"]
+    ROUTE -->|既定| CHECK["CheckChanges<br/>(import --dry-run)"]
     CHECK -->|exit 0<br/>変更なし| END1["完了"]
     CHECK -->|exit 1<br/>変更あり| IMPORT["UpdateData<br/>(import --quiet)"]
     CHECK -->|その他<br/>判定不能| FAIL["実行失敗"]
+    FORCE --> CACHE
     IMPORT --> CACHE["BuildCache"]
     CACHE --> RESTART["RestartService"]
     RESTART --> END2["完了"]
 ```
 
-1. **CheckChanges** (`import --dry-run`) — DCAT Feed と差分検出。変更がなければ完了し、以降の処理は実行されません。判定に失敗した場合は実行が失敗になります。
-2. **UpdateData** (`import --quiet`) — 差分インポート
-3. **BuildCache** — DuckDB キャッシュ再構築
-4. **RestartService** — ECS サービス再起動
+1. **Route** — 実行入力で経路を選びます。`{"rebuild_cache_only": true}` は BuildCache から、`{"force": true}` は ForceImport から始まります。どちらもない場合と `false` の場合は CheckChanges に進みます。
+2. **CheckChanges** (`import --dry-run`) — DCAT Feed と差分検出。変更がなければ完了し、以降の処理は実行されません。判定に失敗した場合は実行が失敗になります。
+3. **ForceImport** (`import --force --quiet`) — 差分検出を飛ばした全件取り込み。取り込み済みのファイルもファイル単位で削除して入れ直すため、古いロジックが生成した行が置き換わります。
+4. **UpdateData** (`import --quiet`) — 差分インポート
+5. **BuildCache** — DuckDB キャッシュ再構築
+6. **RestartService** — ECS サービス再起動
 
 ### 手動トリガー
 
@@ -366,16 +379,34 @@ aws logs filter-log-events \
 
 ### イメージ更新
 
-[初回構築 > Docker イメージのビルド・プッシュ](#docker-イメージのビルド・プッシュ)の手順でイメージを更新後、タスク定義の更新とサービスの再起動を行います。
+[初回構築 > Docker イメージのビルド・プッシュ](#docker-イメージのビルド・プッシュ)の手順でイメージを更新後、キャッシュを再構築します。
 
 ```bash
 cd docs/aws/terraform
 terraform apply
 
-aws ecs update-service --cluster $ECS_CLUSTER --service abrg-service --force-new-deployment
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:ap-northeast-1:$(aws sts get-caller-identity --query Account --output text):stateMachine:abrg-data-update \
+  --input '{"rebuild_cache_only": true}'
 ```
 
-> **⚠️ キャッシュスキーマ版が上がるリリース**: abrg は起動時にキャッシュのスキーマ版を検証し、不一致なら起動を拒否します（`abrg/README.ja.md` 参照）。リリースノートにスキーマ版の変更が含まれる場合は、**先にキャッシュを再構築してからサービスを再起動**してください（新イメージでの [キャッシュビルド](#キャッシュビルド) → [サービス再起動](#サービス再起動) の順。DB のテーブル構成も変わる場合は [設定（取り込みフィルタ）変更の反映](#設定取り込みフィルタ変更の反映) の全手順）。逆順で再起動すると新しいタスクが旧キャッシュを読めず起動失敗を繰り返します。
+`rebuild_cache_only` はキャッシュ構築とサービス再起動だけを実行します。変更内容で場合分けせず、abrg のイメージを push したら常に続けて実行してください。abrg はキャッシュのスキーマ版と正規化の整合を起動時に検証し、どちらかが食い違うと起動を拒否します（`abrg/README.ja.md` 参照）。順序が逆になると、新しいタスクが旧キャッシュを読めずに起動失敗を繰り返します。
+
+abrdb の取り込みロジックが変わるリリースでは、キャッシュだけでなく取り込み済みデータの作り直しが必要です。`{"force": true}` は差分チェックを飛ばして全件を取り込み直し、そのままキャッシュ構築とサービス再起動まで続けます。
+
+```bash
+aws stepfunctions start-execution \
+  --state-machine-arn arn:aws:states:ap-northeast-1:$(aws sts get-caller-identity --query Account --output text):stateMachine:abrg-data-update \
+  --input '{"force": true}'
+```
+
+値は真偽値で渡します。文字列の `"true"` は一致せず、差分チェックから始まる通常経路に落ちます。
+
+> **⚠️ 定期実行との重複**: 定期実行（毎日 02:00 JST）と手動実行が重なると、同じキャッシュ保存先に二重に書き込みます。時間帯を避けて実行してください。
+
+> **⚠️ 列構成が変わる abrdb のリリース**: 取り込み自体がエラーで止まるため `force` では復旧できません。[設定（取り込みフィルタ）変更の反映](#設定取り込みフィルタ変更の反映) の `init` からの手順を実行してください。人が実行するまで日次実行も失敗し続けます。また `force` はファイル単位の削除と再挿入のため、繰り返すとデータベースに未回収の領域が残ります。大規模な入れ直しを繰り返す場合も `init` からの手順を使ってください。
+
+ワークフローの成功はサービスが定常状態に達したことまでは保証しません。実行後に [動作確認](#動作確認) を行ってください。起動拒否が続く場合は deployment circuit breaker がデプロイを止め、直前の定常状態に戻します。
 
 ### 設定（取り込みフィルタ）変更の反映
 
@@ -406,7 +437,18 @@ aws ecs run-task --cluster $ECS_CLUSTER --task-definition abrdb-import --launch-
 
 ### ロールバック
 
-キャッシュは稼働中バイナリの要求するスキーマ版と一致している必要があります。バイナリ更新をまたいで古いキャッシュに戻す場合は、イメージも同時に戻すか、現行バイナリで `cache build` し直してください。
+キャッシュは稼働中バイナリと組で整合している必要があります。スキーマ版と正規化のどちらが食い違っても起動を拒否されるため、イメージとキャッシュは同じ世代の組に戻します。
+
+タスク定義は `:latest` を参照するので、旧バージョンタグを `:latest` に付け替えた上で、S3 のバージョニングから1世代前のキャッシュに戻します。整合した組に戻るため、キャッシュの再構築を待たずに復旧できます。
+
+```bash
+# 旧バージョンを latest に付け替える（例: 3.0.40 へ戻す）
+MANIFEST=$(aws ecr batch-get-image --repository-name abrg \
+  --image-ids imageTag=3.0.40 --query 'images[0].imageManifest' --output text)
+aws ecr put-image --repository-name abrg --image-tag latest --image-manifest "$MANIFEST"
+```
+
+S3 のキャッシュは非現行バージョンを30日で失効させるため、それより前には戻せません。その場合は現行バイナリで `cache build` し直してください。
 
 ```bash
 # S3 バージョン一覧確認

--- a/docs/aws/terraform/modules/api_gateway/main.tf
+++ b/docs/aws/terraform/modules/api_gateway/main.tf
@@ -200,6 +200,16 @@ resource "aws_api_gateway_integration_response" "root_options" {
 # error then surfaces as a CORS problem rather than as the 403 or 429 it is.
 # Only the origin is needed: these answer the actual request, not a preflight.
 
+locals {
+  # API Gateway serves this body for DEFAULT_4XX and DEFAULT_5XX unless a
+  # template is given. Declaring it keeps the resource in step with what the
+  # gateway already returns; leaving it out reads back as a permanent diff
+  # that would clear the body on the next apply.
+  gateway_error_template = {
+    "application/json" = "{\"message\":$context.error.messageString}"
+  }
+}
+
 resource "aws_api_gateway_gateway_response" "default_4xx" {
   rest_api_id   = aws_api_gateway_rest_api.main.id
   response_type = "DEFAULT_4XX"
@@ -207,6 +217,8 @@ resource "aws_api_gateway_gateway_response" "default_4xx" {
   response_parameters = {
     "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.cors_allow_origin}'"
   }
+
+  response_templates = local.gateway_error_template
 }
 
 resource "aws_api_gateway_gateway_response" "default_5xx" {
@@ -216,6 +228,8 @@ resource "aws_api_gateway_gateway_response" "default_5xx" {
   response_parameters = {
     "gatewayresponse.header.Access-Control-Allow-Origin" = "'${var.cors_allow_origin}'"
   }
+
+  response_templates = local.gateway_error_template
 }
 
 resource "aws_api_gateway_deployment" "main" {

--- a/docs/aws/terraform/modules/ecs/main.tf
+++ b/docs/aws/terraform/modules/ecs/main.tf
@@ -523,6 +523,15 @@ resource "aws_ecs_service" "abrg" {
   desired_count   = 1
   launch_type     = "FARGATE"
 
+  # abrg refuses to start on a cache it cannot read, so a deployment that
+  # pairs a new binary with an incompatible cache would otherwise retry
+  # forever. The circuit breaker stops it and returns to the last deployment
+  # that reached steady state.
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
   network_configuration {
     subnets          = var.private_subnet_ids
     security_groups  = [var.ecs_security_group_id]

--- a/docs/aws/terraform/modules/workflow/main.tf
+++ b/docs/aws/terraform/modules/workflow/main.tf
@@ -1,16 +1,21 @@
 # Workflow Module - Step Functions + EventBridge for automated data updates
 #
 # Workflow:
-#   EventBridge (schedule) -> Step Functions -> ECS Tasks -> ECS Service restart
+#   EventBridge (schedule) or a manual execution -> Step Functions -> ECS tasks
+#   -> ECS service restart
 #
 # Steps:
 #   1. abrdb import (check & import if changes)
 #   2. abrg cache build
 #   3. ECS service force-new-deployment
 #
-# Note: Daily updates use lower task specs via Overrides (2vCPU/4GB for import,
-#       4vCPU/8GB for cache build). For full imports, run tasks manually with
-#       default specs (16vCPU/32GB) or override via aws ecs run-task.
+# The execution input can skip ahead: rebuild_cache_only starts at the cache
+# build, force replaces the change check with a full re-import. Both exist for
+# releases where the code changed but the data did not.
+#
+# Every state overrides the task spec down to what a daily run needs (2vCPU/4GB
+# for import, 4vCPU/16GB for cache build) except ForceImport, which keeps the
+# task definition's own 8vCPU/16GB for a full volume.
 
 # IAM Role for Step Functions
 resource "aws_iam_role" "step_functions" {
@@ -224,8 +229,7 @@ resource "aws_sfn_state_machine" "data_update" {
       # guaranteed. A hung task costs nothing while it hangs - the service
       # keeps serving the cache it already loaded - whereas a timeout that
       # fires on a healthy run fails the update. Each value therefore covers
-      # the worst case that task can legitimately reach, which is a different
-      # quantity for each of them and is noted where they are set.
+      # the worst case its own task can legitimately reach.
       #
       # Comparing the DCAT feed against the catalog costs the same whatever
       # changed, so this one only has to cover its own spread.

--- a/docs/aws/terraform/modules/workflow/main.tf
+++ b/docs/aws/terraform/modules/workflow/main.tf
@@ -210,18 +210,23 @@ resource "aws_sfn_state_machine" "data_update" {
       # Step 1: Check for changes (dry-run)
       # - exit 0: no changes -> end workflow
       # - exit 1: changes pending -> continue to import (caught as task failure)
+      #
       # TimeoutSeconds exists to stop the workflow blocking forever on a hung
       # task (e.g. an uncancellable DuckDB query), not to flag a slow one. On
       # timeout the execution fails and Step Functions attempts a best-effort
       # cancellation (ecs:StopTask) of the .sync task; the stop itself is not
       # guaranteed. A hung task costs nothing while it hangs - the service
       # keeps serving the cache it already loaded - whereas a timeout that
-      # fires on a healthy run fails the update, so each value sits well above
-      # the durations observed for that task rather than close to them.
+      # fires on a healthy run fails the update. Each value therefore covers
+      # the worst case that task can legitimately reach, which is a different
+      # quantity for each of them and is noted where they are set.
+      #
+      # Comparing the DCAT feed against the catalog costs the same whatever
+      # changed, so this one only has to cover its own spread.
       CheckChanges = {
         Type           = "Task"
         Resource       = "arn:aws:states:::ecs:runTask.sync"
-        TimeoutSeconds = 900
+        TimeoutSeconds = 300
         Parameters = {
           Cluster        = var.ecs_cluster_arn
           TaskDefinition = var.abrdb_import_task_arn
@@ -304,6 +309,11 @@ resource "aws_sfn_state_machine" "data_update" {
         Comment = "No changes detected, workflow complete"
       }
       # Step 2: Import data (with changes detected)
+      # An ordinary day is a minute or two, but this scales with how much ABR
+      # republished, so the case to cover is every file changing at once. That
+      # is the same work ForceImport does, and it runs here under the smaller
+      # daily spec - not proportionally slower, since import throughput is
+      # bound by Aurora writes rather than CPU.
       UpdateData = {
         Type           = "Task"
         Resource       = "arn:aws:states:::ecs:runTask.sync"
@@ -336,6 +346,8 @@ resource "aws_sfn_state_machine" "data_update" {
         Next = "BuildCache"
       }
       # Step 3: Build cache
+      # Every run rebuilds the whole cache, so there is no busy day to allow
+      # for - only the spread between runs and the dataset growing.
       BuildCache = {
         Type           = "Task"
         Resource       = "arn:aws:states:::ecs:runTask.sync"

--- a/docs/aws/terraform/modules/workflow/main.tf
+++ b/docs/aws/terraform/modules/workflow/main.tf
@@ -117,6 +117,18 @@ resource "aws_cloudwatch_log_group" "step_functions" {
   }
 }
 
+locals {
+  # Every task state in this workflow runs on the same private subnets with
+  # the same security group, so the wiring is declared once here.
+  task_network_configuration = {
+    AwsvpcConfiguration = {
+      Subnets        = var.private_subnet_ids
+      SecurityGroups = [var.ecs_security_group_id]
+      AssignPublicIp = "DISABLED"
+    }
+  }
+}
+
 # Step Functions State Machine
 resource "aws_sfn_state_machine" "data_update" {
   name     = "${var.project_name}-data-update"
@@ -183,16 +195,10 @@ resource "aws_sfn_state_machine" "data_update" {
         Resource       = "arn:aws:states:::ecs:runTask.sync"
         TimeoutSeconds = var.force_import_timeout_seconds
         Parameters = {
-          Cluster        = var.ecs_cluster_arn
-          TaskDefinition = var.abrdb_import_task_arn
-          LaunchType     = "FARGATE"
-          NetworkConfiguration = {
-            AwsvpcConfiguration = {
-              Subnets        = var.private_subnet_ids
-              SecurityGroups = [var.ecs_security_group_id]
-              AssignPublicIp = "DISABLED"
-            }
-          }
+          Cluster              = var.ecs_cluster_arn
+          TaskDefinition       = var.abrdb_import_task_arn
+          LaunchType           = "FARGATE"
+          NetworkConfiguration = local.task_network_configuration
           Overrides = {
             ContainerOverrides = [
               {
@@ -228,16 +234,10 @@ resource "aws_sfn_state_machine" "data_update" {
         Resource       = "arn:aws:states:::ecs:runTask.sync"
         TimeoutSeconds = 300
         Parameters = {
-          Cluster        = var.ecs_cluster_arn
-          TaskDefinition = var.abrdb_import_task_arn
-          LaunchType     = "FARGATE"
-          NetworkConfiguration = {
-            AwsvpcConfiguration = {
-              Subnets        = var.private_subnet_ids
-              SecurityGroups = [var.ecs_security_group_id]
-              AssignPublicIp = "DISABLED"
-            }
-          }
+          Cluster              = var.ecs_cluster_arn
+          TaskDefinition       = var.abrdb_import_task_arn
+          LaunchType           = "FARGATE"
+          NetworkConfiguration = local.task_network_configuration
           Overrides = {
             Cpu    = "1024"
             Memory = "2048"
@@ -319,16 +319,10 @@ resource "aws_sfn_state_machine" "data_update" {
         Resource       = "arn:aws:states:::ecs:runTask.sync"
         TimeoutSeconds = 3600
         Parameters = {
-          Cluster        = var.ecs_cluster_arn
-          TaskDefinition = var.abrdb_import_task_arn
-          LaunchType     = "FARGATE"
-          NetworkConfiguration = {
-            AwsvpcConfiguration = {
-              Subnets        = var.private_subnet_ids
-              SecurityGroups = [var.ecs_security_group_id]
-              AssignPublicIp = "DISABLED"
-            }
-          }
+          Cluster              = var.ecs_cluster_arn
+          TaskDefinition       = var.abrdb_import_task_arn
+          LaunchType           = "FARGATE"
+          NetworkConfiguration = local.task_network_configuration
           Overrides = {
             Cpu    = var.daily_import_cpu
             Memory = var.daily_import_memory
@@ -353,16 +347,10 @@ resource "aws_sfn_state_machine" "data_update" {
         Resource       = "arn:aws:states:::ecs:runTask.sync"
         TimeoutSeconds = 1800
         Parameters = {
-          Cluster        = var.ecs_cluster_arn
-          TaskDefinition = var.abrg_cache_build_task_arn
-          LaunchType     = "FARGATE"
-          NetworkConfiguration = {
-            AwsvpcConfiguration = {
-              Subnets        = var.private_subnet_ids
-              SecurityGroups = [var.ecs_security_group_id]
-              AssignPublicIp = "DISABLED"
-            }
-          }
+          Cluster              = var.ecs_cluster_arn
+          TaskDefinition       = var.abrg_cache_build_task_arn
+          LaunchType           = "FARGATE"
+          NetworkConfiguration = local.task_network_configuration
           Overrides = {
             Cpu    = var.daily_cache_build_cpu
             Memory = var.daily_cache_build_memory

--- a/docs/aws/terraform/modules/workflow/main.tf
+++ b/docs/aws/terraform/modules/workflow/main.tf
@@ -130,16 +130,94 @@ resource "aws_sfn_state_machine" "data_update" {
 
   definition = jsonencode({
     Comment = "ABR data update workflow: check changes -> import -> cache build -> service restart"
-    StartAt = "CheckChanges"
+    StartAt = "Route"
     States = {
+      # Manual releases enter here. The scheduled run carries both keys set to
+      # false and falls through to CheckChanges.
+      #
+      # Each key is guarded by IsPresent because a Choice that reads an absent
+      # path fails the execution itself. BooleanEquals also means the string
+      # "true" does not match and lands on the default branch, so the input
+      # has to carry real booleans.
+      Route = {
+        Type = "Choice"
+        Choices = [
+          {
+            And = [
+              {
+                Variable  = "$.rebuild_cache_only"
+                IsPresent = true
+              },
+              {
+                Variable      = "$.rebuild_cache_only"
+                BooleanEquals = true
+              }
+            ]
+            Next = "BuildCache"
+          },
+          {
+            And = [
+              {
+                Variable  = "$.force"
+                IsPresent = true
+              },
+              {
+                Variable      = "$.force"
+                BooleanEquals = true
+              }
+            ]
+            Next = "ForceImport"
+          }
+        ]
+        Default = "CheckChanges"
+      }
+      # abrdb import detects unchanged files and skips them, so a plain import
+      # cannot re-run the ETL after a logic change. --force deletes and
+      # re-inserts per file, replacing rows an older logic produced.
+      #
+      # No Cpu/Memory override: the daily values are sized for an incremental
+      # import and a full one runs out of memory under them. The task
+      # definition's own spec applies instead.
+      ForceImport = {
+        Type           = "Task"
+        Resource       = "arn:aws:states:::ecs:runTask.sync"
+        TimeoutSeconds = var.force_import_timeout_seconds
+        Parameters = {
+          Cluster        = var.ecs_cluster_arn
+          TaskDefinition = var.abrdb_import_task_arn
+          LaunchType     = "FARGATE"
+          NetworkConfiguration = {
+            AwsvpcConfiguration = {
+              Subnets        = var.private_subnet_ids
+              SecurityGroups = [var.ecs_security_group_id]
+              AssignPublicIp = "DISABLED"
+            }
+          }
+          Overrides = {
+            ContainerOverrides = [
+              {
+                Name    = "abrdb"
+                Command = ["import", "--force", "--quiet"]
+                Environment = [
+                  { Name = "LOG_LEVEL", Value = "info" }
+                ]
+              }
+            ]
+          }
+        }
+        Next = "BuildCache"
+      }
       # Step 1: Check for changes (dry-run)
       # - exit 0: no changes -> end workflow
       # - exit 1: changes pending -> continue to import (caught as task failure)
-      # TimeoutSeconds on each task is 5-10x its measured normal duration.
-      # On timeout the execution fails and Step Functions attempts a
-      # best-effort cancellation (ecs:StopTask) of the .sync task - the stop
-      # itself is not guaranteed, but the timeout bounds how long the
-      # workflow can block on a hung task (e.g. an uncancellable DuckDB query).
+      # TimeoutSeconds exists to stop the workflow blocking forever on a hung
+      # task (e.g. an uncancellable DuckDB query), not to flag a slow one. On
+      # timeout the execution fails and Step Functions attempts a best-effort
+      # cancellation (ecs:StopTask) of the .sync task; the stop itself is not
+      # guaranteed. A hung task costs nothing while it hangs - the service
+      # keeps serving the cache it already loaded - whereas a timeout that
+      # fires on a healthy run fails the update, so each value sits well above
+      # the durations observed for that task rather than close to them.
       CheckChanges = {
         Type           = "Task"
         Resource       = "arn:aws:states:::ecs:runTask.sync"
@@ -355,6 +433,13 @@ resource "aws_scheduler_schedule" "daily_update" {
   target {
     arn      = aws_sfn_state_machine.data_update.arn
     role_arn = aws_iam_role.eventbridge[0].arn
+
+    # Both keys are spelled out so the Route choice sees them present and
+    # false rather than absent.
+    input = jsonencode({
+      force              = false
+      rebuild_cache_only = false
+    })
   }
 
   state = "ENABLED"

--- a/docs/aws/terraform/modules/workflow/variables.tf
+++ b/docs/aws/terraform/modules/workflow/variables.tf
@@ -82,3 +82,9 @@ variable "daily_cache_build_memory" {
   default     = "16384" # 16 GB (vs 32 GB for full import)
   description = "Memory (MB) for daily cache build task"
 }
+
+variable "force_import_timeout_seconds" {
+  type        = number
+  default     = 2700 # 45 min, against a measured full re-import of 14 min
+  description = "Timeout for the full re-import triggered by {\"force\": true}"
+}

--- a/docs/aws/terraform/modules/workflow/variables.tf
+++ b/docs/aws/terraform/modules/workflow/variables.tf
@@ -85,6 +85,6 @@ variable "daily_cache_build_memory" {
 
 variable "force_import_timeout_seconds" {
   type        = number
-  default     = 2700 # 45 min, against a measured full re-import of 14 min
+  default     = 2700 # covers a full re-import, measured at 14 min
   description = "Timeout for the full re-import triggered by {\"force\": true}"
 }

--- a/docs/aws/terraform/modules/workflow/variables.tf
+++ b/docs/aws/terraform/modules/workflow/variables.tf
@@ -61,25 +61,25 @@ variable "log_retention_days" {
 # Daily update task specs (lower than full import)
 variable "daily_import_cpu" {
   type        = string
-  default     = "2048" # 2 vCPU (vs 16 vCPU for full import)
+  default     = "2048" # 2 vCPU (the task definition allows 8)
   description = "CPU units for daily import task"
 }
 
 variable "daily_import_memory" {
   type        = string
-  default     = "4096" # 4 GB (vs 32 GB for full import)
+  default     = "4096" # 4 GB (the task definition allows 16)
   description = "Memory (MB) for daily import task"
 }
 
 variable "daily_cache_build_cpu" {
   type        = string
-  default     = "4096" # 4 vCPU (vs 16 vCPU for full import)
+  default     = "4096" # 4 vCPU (the task definition allows 8)
   description = "CPU units for daily cache build task"
 }
 
 variable "daily_cache_build_memory" {
   type        = string
-  default     = "16384" # 16 GB (vs 32 GB for full import)
+  default     = "16384" # 16 GB (the task definition allows 32)
   description = "Memory (MB) for daily cache build task"
 }
 


### PR DESCRIPTION
refs #331

## 背景

日次のデータ更新ワークフローは、冒頭の差分チェックで新しいデータがなければ取り込みもキャッシュ構築も行わない。abrg や abrdb のコードが変わるリリースでは、データが変わらなくてもキャッシュや取り込み済みデータの作り直しが必要だが、ワークフローを通してそれを行う手段がなかった。

## 変更

実行入力で2種類の手動実行を追加する。差分チェックの手前に `Route` を置き、入力に応じて経路を選ぶ。

- `{"rebuild_cache_only": true}`: キャッシュ構築とサービス再起動だけを実行する。abrg 側の変更のリリースで使う既定の手順
- `{"force": true}`: 差分チェックを飛ばし、`import --force` による全件取り込みから通常の後続を実行する

`ForceImport` を専用ステートにしたのは、abrdb import が自前の変更検知を持ち、既定のままでは更新のないファイルを取り込まないため。`--force` はファイル単位の削除と再挿入で、古いロジックが生成した行も置き換わる。このステートだけ Cpu と Memory の上書きを付けない。日次用の小さいスペックは差分取り込み向けで、全件では足りない。

分岐は `IsPresent` と値の判定を AND で組む。存在しないパスを直接参照すると、キーのない入力で実行そのものが失敗する。真偽値で比較するため、文字列の `"true"` は一致せず通常経路に落ちる。定期実行のスケジュールにも両方のキーを明示する。

あわせて次を含む。

- サービスに deployment circuit breaker を有効化する。#330 の起動拒否が続いた場合に、タスクの起動失敗が繰り返されるのを止める
- API Gateway の `DEFAULT_4XX` / `DEFAULT_5XX` に、ゲートウェイが既に返しているエラー本文を宣言する。未宣言のままだと恒久的な差分として読み戻され、apply で本文が消える
- `CheckChanges` のタイムアウトを 900 秒から 300 秒に下げる。DCAT フィードと catalog の突き合わせは変更量に依存しない固定費で、他のステートが持つ「全件が変わった日」の余裕を必要としない
- 4つのタスクステートが同じ内容を持っていた `NetworkConfiguration` を `locals` にまとめる

## ドキュメント

`docs/aws/README.md` のリリース手順を、変更内容で場合分けせず常に `rebuild_cache_only` を続ける形に改める。イメージはバージョンタグを併せて push し、ロールバックでは戻す先のイメージが作ったキャッシュを `LastModified` から選ぶ。単純に1世代前を選ぶと、リリース後にキャッシュが作り直されていた場合に整合しない組になる。
