### PR TITLE
実在しない住所を使っていたユニットテストを実データに置き換え、dbSteps を検査可能にする

### DIFF
--- a/abrg/internal/matching/detect_machiaza_test.go
+++ b/abrg/internal/matching/detect_machiaza_test.go
@@ -144,35 +144,37 @@ func TestBuildFallbackAddress(t *testing.T) {
 	}{
 		{
 			name:              "With colon and single digit",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "1-3",
-			expectedFallback:  "千代田区紀尾井町1@",
+			expectedFallback:  "千代田区神田佐久間町1@",
 			expectedRemaining: ":3",
 		},
 		{
+			// 123丁目 and 0丁目 exist nowhere: ABR tops out at 42丁目. These
+			// three pin how the digits are split, not a real address.
 			name:              "With colon and multi-digit",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "123-456",
-			expectedFallback:  "千代田区紀尾井町123@",
+			expectedFallback:  "千代田区神田佐久間町123@",
 			expectedRemaining: ":456",
 		},
 		{
 			name:              "No number after colon",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "",
 			expectedFallback:  "",
 			expectedRemaining: "",
 		},
 		{
 			name:              "Japanese text after colon",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "文字列",
 			expectedFallback:  "",
 			expectedRemaining: "",
 		},
 		{
 			name:              "Space before number",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        " 1-3",
 			expectedFallback:  "",
 			expectedRemaining: "",
@@ -193,16 +195,16 @@ func TestBuildFallbackAddress(t *testing.T) {
 		},
 		{
 			name:              "Zero",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "0-1",
-			expectedFallback:  "千代田区紀尾井町0@",
+			expectedFallback:  "千代田区神田佐久間町0@",
 			expectedRemaining: ":1",
 		},
 		{
 			name:              "Number without hyphen",
-			baseAddress:       "千代田区紀尾井町",
+			baseAddress:       "千代田区神田佐久間町",
 			afterColon:        "123",
-			expectedFallback:  "千代田区紀尾井町123@",
+			expectedFallback:  "千代田区神田佐久間町123@",
 			expectedRemaining: "",
 		},
 		{

--- a/abrg/internal/matching/impl_test.go
+++ b/abrg/internal/matching/impl_test.go
@@ -257,12 +257,12 @@ func TestBuildParcelSearchAddr(t *testing.T) {
 		{
 			name: "with koaza",
 			sa: &model.StructuredAddress{
-				City:    new("新宿区"),
-				OazaCho: new("西新宿"),
-				Koaza:   new("北町"),
+				City:    new("七尾市"),
+				OazaCho: new("柑子町"),
+				Koaza:   new("チ"),
 			},
 			afterColon: "100",
-			expected:   "新宿区西新宿北町:100",
+			expected:   "七尾市柑子町チ:100",
 		},
 		{
 			name: "empty afterColon",
@@ -308,7 +308,7 @@ func BenchmarkNormalize(b *testing.B) {
 			Limit:    1,
 		},
 		{
-			Address:  "岡山県阿哲郡神郷下神代2029番地",
+			Address:  "岡山県新見市神郷下神代2029番地",
 			Category: model.CategoryParcel,
 			Pref:     "all",
 			Limit:    1,

--- a/abrg/internal/transform/chome_test.go
+++ b/abrg/internal/transform/chome_test.go
@@ -34,7 +34,7 @@ func TestChomeToSymbol(t *testing.T) {
 			expected: "NOTアラビア数字丁目",
 		},
 		{
-			name:     "chome with ban - no change (should be handled by banchi)",
+			name:     "chome symbol applied, 番 left for the banchi rules",
 			input:    "1丁目2番",
 			expected: "1@2番",
 		},

--- a/abrg/internal/transform/colon.go
+++ b/abrg/internal/transform/colon.go
@@ -113,7 +113,7 @@ func isSingleKatakanaColon(result string) bool {
 }
 
 // AddColon inserts a colon separator between text and trailing address number.
-// Example: "米花町492-1" -> "米花町:492-1".
+// Example: "紀尾井町1-3" -> "紀尾井町:1-3".
 func AddColon(s string) (string, bool) {
 	if strings.Contains(s, ":") {
 		return s, false

--- a/abrg/internal/transform/colon_test.go
+++ b/abrg/internal/transform/colon_test.go
@@ -211,8 +211,8 @@ func TestAddColon(t *testing.T) {
 		{
 			// 街区 koaza pattern (isGaikuPattern).
 			name:     "gaiku pattern suppresses colon",
-			input:    "米花町13街区5号",
-			expected: "米花町13街区5号",
+			input:    "宮崎県都城市平江町13街区5号",
+			expected: "宮崎県都城市平江町13街区5号",
 			changed:  false,
 		},
 		{
@@ -225,8 +225,8 @@ func TestAddColon(t *testing.T) {
 		{
 			// A trailing single katakana is likely a koaza, so the colon is reverted.
 			name:     "trailing single katakana reverts colon",
-			input:    "米花町イ",
-			expected: "米花町イ",
+			input:    "七尾市柑子町チ",
+			expected: "七尾市柑子町チ",
 			changed:  false,
 		},
 	}

--- a/abrg/internal/transform/hokkaido_test.go
+++ b/abrg/internal/transform/hokkaido_test.go
@@ -77,7 +77,7 @@ func TestExtractSenGoSuffix(t *testing.T) {
 		{"旭川市東鷹栖11線23号", "旭川市東鷹栖11線", "23号", true},
 		{"旭川市東鷹栖12線22号", "旭川市東鷹栖12線", "22号", true},
 		// With direction (方角)
-		{"旭川市東鷹栖10線西5号", "旭川市東鷹栖10線西", "5号", true},
+		{"旭川市近文7線南1号", "旭川市近文7線南", "1号", true},
 		// Not extractable
 		{"上川郡鷹栖町7線", "", "", false},      // no 号
 		{"標津郡標津町茶志骨6線南", "", "", false},  // 6線南 is oaza_cho, not sen-go

--- a/abrg/internal/transform/kana_test.go
+++ b/abrg/internal/transform/kana_test.go
@@ -118,7 +118,7 @@ func TestHiraganaToKatakana(t *testing.T) {
 			changed:  true,
 		},
 		{
-			name:     "real address example",
+			name:     "address spelled entirely in kana",
 			input:    "とうきょうとちよだくきおいちょう",
 			expected: "トウキョウトチヨダクキオイチョウ",
 			changed:  true,
@@ -156,7 +156,7 @@ func BenchmarkHiraganaToKatakana(b *testing.B) {
 		"カタカナ",     // No change
 		"あいうえお",    // Basic hiragana
 		"ひらがなカタカナ", // Mixed
-		"とうきょうとちよだくきおいちょう",          // Real world example
+		"とうきょうとちよだくきおいちょう",          // Address-length kana run
 		"あいうえおかきくけこさしすせそたちつてとなにぬねの", // Long hiragana string
 	}
 

--- a/abrg/internal/transform/sapporo_test.go
+++ b/abrg/internal/transform/sapporo_test.go
@@ -19,9 +19,11 @@ func TestExpandSapporoJou(t *testing.T) {
 			changed:  true,
 		},
 		{
+			// 南N条東M丁目 is Chuo-ku and Abashiri, never Higashi-ku, which has
+			// no 南 series at all.
 			name:     "南東 pattern",
-			input:    "札幌市東区南10東5-3",
-			expected: "札幌市東区南10条東5丁目:3",
+			input:    "網走市南10東5-3",
+			expected: "網走市南10条東5丁目:3",
 			changed:  true,
 		},
 		{

--- a/abrg/internal/transform/text_test.go
+++ b/abrg/internal/transform/text_test.go
@@ -63,6 +63,13 @@ func TestTextForBasicNormalized(t *testing.T) {
 			want:    "北3条西1@:-7", // KanjiToArabic → expandSapporoJou → AddColon → ChomeToSymbol
 			changed: true,
 		},
+		{
+			// NormalizeSpaces collapses the run and drops the ideographic space.
+			name:    "ideographic and repeated spaces are collapsed",
+			input:   "名古屋市中区栄1丁目　　3",
+			want:    "名古屋市中区栄1@ 3",
+			changed: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -73,6 +80,107 @@ func TestTextForBasicNormalized(t *testing.T) {
 			}
 			if changed != tt.changed {
 				t.Errorf("TextForBasicNormalized() changed = %v, want %v", changed, tt.changed)
+			}
+		})
+	}
+}
+
+// TestTextForDB pins the dbSteps pipeline that cache build runs as the
+// normalize_text_go UDF. Every input is a real cache_machiaza row concatenated
+// the way normalizedExpr concatenates it, so the want value is the
+// normalized_address the cache actually stores.
+func TestTextForDB(t *testing.T) {
+	tests := []struct {
+		name    string
+		step    string
+		input   string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "variant kanji 竈 becomes 釜",
+			step:    "StandardizeSpecialChars",
+			input:   "度会郡南伊勢町道行竈", // lg_code 244724 / machiaza_id 0036000
+			want:    "度会郡南伊勢町道行釜",
+			changed: true,
+		},
+		{
+			name:    "compatibility ideograph 塚 U+FA10 becomes U+585A",
+			step:    "NFKCNormalize",
+			input:   "神戸市中央区割塚通7丁目", // lg_code 281107 / machiaza_id 0019007
+			want:    "神戸市中央区割塚通7@",
+			changed: true,
+		},
+		{
+			name:    "horizontal bar U+2015 becomes a hyphen",
+			step:    "NormalizeDashes",
+			input:   "仙台市宮城野区小田原幸町公団アパ―ト", // lg_code 041025 / machiaza_id 0107000
+			want:    "仙台市宮城野区小田原幸町公団アパ-ト",
+			changed: true,
+		},
+		{
+			// The prolonged sound mark converts only between digits, which is
+			// why 公団アパート above keeps its ー.
+			name:    "prolonged sound mark between digits becomes a hyphen",
+			step:    "NormalizeDashes",
+			input:   "知立市知立駅周17ー1街区", // lg_code 232254 / machiaza_id 0057000
+			want:    "知立市知立駅周17-1街区",
+			changed: true,
+		},
+		{
+			name:    "大字 and 字 are dropped",
+			step:    "RemoveOazaAza",
+			input:   "厚岸郡浜中町大字後静村字姉別原野南9線", // lg_code 016632 / machiaza_id 0144172
+			want:    "厚岸郡浜中町後静村姉別原野南9線",
+			changed: true,
+		},
+		{
+			name:    "hiragana の becomes katakana ノ",
+			step:    "hiraganaToKatakana",
+			input:   "倉敷市児島下の町9丁目", // lg_code 332020 / machiaza_id 0057009
+			want:    "倉敷市児島下ノ町9@",
+			changed: true,
+		},
+		{
+			name:    "formal kanji numeral 壱 becomes 1",
+			step:    "KanjiToArabic",
+			input:   "上尾市壱丁目南", // lg_code 112194 / machiaza_id 0078000
+			want:    "上尾市1@南",
+			changed: true,
+		},
+		{
+			name:    "丁目 becomes the chome symbol",
+			step:    "ChomeToSymbol",
+			input:   "浦安市舞浜2丁目", // lg_code 122271 / machiaza_id 0018002
+			want:    "浦安市舞浜2@",
+			changed: true,
+		},
+		{
+			// AddColon is deliberately absent from dbSteps, so a trailing
+			// number stays attached to the place name.
+			name:    "no colon is inserted",
+			step:    "AddColon is not in dbSteps",
+			input:   "知立市知立駅周17ー1街区",
+			want:    "知立市知立駅周17-1街区",
+			changed: true,
+		},
+		{
+			name:    "empty string",
+			step:    "-",
+			input:   "",
+			want:    "",
+			changed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := textForDB(tt.input)
+			if got != tt.want {
+				t.Errorf("textForDB(%q) [%s] = %q, want %q", tt.input, tt.step, got, tt.want)
+			}
+			if changed != tt.changed {
+				t.Errorf("textForDB(%q) [%s] changed = %v, want %v", tt.input, tt.step, changed, tt.changed)
 			}
 		})
 	}

--- a/abrg/internal/transform/text_test.go
+++ b/abrg/internal/transform/text_test.go
@@ -16,7 +16,7 @@ func TestTextForBasicNormalized(t *testing.T) {
 			changed: false,
 		},
 		{
-			name:    "no change needed",
+			name:    "kanji numeral in a city name is converted",
 			input:   "東京都千代田区",
 			want:    "東京都1000代田区",
 			changed: true,
@@ -52,7 +52,7 @@ func TestTextForBasicNormalized(t *testing.T) {
 			changed: true,
 		},
 		{
-			name:    "address with building name separator",
+			name:    "kanji numeral in a town name with address numbers",
 			input:   "三輪2-1-1",
 			want:    "3輪:2-1-1",
 			changed: true,
@@ -183,5 +183,23 @@ func TestTextForDB(t *testing.T) {
 				t.Errorf("textForDB(%q) [%s] changed = %v, want %v", tt.input, tt.step, changed, tt.changed)
 			}
 		})
+	}
+}
+
+// A cache record and a query reach each other only where the two pipelines
+// agree, so NormalizeSpaces has to sit in both. No oaza_cho or koaza in the
+// cache holds whitespace today, which is why the step is pinned by the
+// agreement rather than by a row.
+func TestSpaceCollapsingIsTheSameOnBothPipelines(t *testing.T) {
+	for _, in := range []string{
+		"倉敷市児島下の町　9丁目",
+		"厚岸郡浜中町大字後静村  字姉別原野南9線",
+	} {
+		db, _ := textForDB(in)
+		basic, _ := TextForBasicNormalized(in)
+		if db != basic {
+			t.Errorf("textForDB(%q) = %q, TextForBasicNormalized = %q; the pipelines must collapse spaces alike",
+				in, db, basic)
+		}
 	}
 }


### PR DESCRIPTION
`internal/transform` と `internal/matching` のユニットテストを実データで点検し、
実在しない住所を使っていたものを実在の町字に差し替えた。あわせて、変異検査で
どのテストにも守られていないことが分かった正規化の段にテストを足した。

挙動は変えていない。

## 実在しない住所の差し替え

いずれも「その住所が実在しない」ため、期待値が正しいかを確かめる手立てが無かった。
差し替え後の出力は差し替え前と同じで、通る経路も変わらない。

| 差し替え前 | 差し替え後 | 理由 |
| :--- | :--- | :--- |
| `米花町13街区5号` | `宮崎県都城市平江町13街区5号` | 米花町は全国に存在しない。lg_code 452025 / machiaza_id 0069000 は街区 13・住居番号 5 まで実在する |
| `米花町イ` | `七尾市柑子町チ` | 同上。lg_code 172022 / machiaza_id 0041112 の小字 `チ` |
| `札幌市東区南10東5-3` | `網走市南10東5-3` | 東区に `南N条` の町字は 0 件。`南10条東5丁目` は lg_code 012114 の網走市に実在する |
| `千代田区紀尾井町` ×7 | `千代田区神田佐久間町` | 紀尾井町に丁目は無い。神田佐久間町は一丁目から四丁目まで実在する |
| `新宿区西新宿` + 小字 `北町` | `七尾市柑子町` + `チ` | 西新宿に小字は無く、北町は独立した別の町字 |
| `旭川市東鷹栖10線西5号` | `旭川市近文7線南1号` | 東鷹栖10線に方角の枝は無い。lg_code 012041 / machiaza_id 0362101 |
| `岡山県阿哲郡神郷下神代2029番地` | `岡山県新見市神郷下神代2029番地` | 阿哲郡は 2005 年に消滅 |

`buildFallbackAddress` の `123@` と `0@` は桁境界の検査で、丁目が 42 までしか無い ABR には
対応する実在住所が無い。町字を実在のものにしたうえで、境界の検査であることをコメントに書いた。

## 名前が中身と違うテスト

4 件。2 件は `no change` と名乗りながら期待値が入力を変えており、1 件は建物名の分離を
名乗りながら入力に建物名が無く、1 件は住所を全部かなで書いた形を `real address example` と
呼んでいた。名前を実際の挙動に合わせた。

## dbSteps のテスト

`textForDB` はキャッシュ構築時に `normalize_text_go` として走り、727,368 件すべての
`normalized_address` を作る。この関数の出力を固定したテストが無く、8 段のうち 6 段は
どれを外しても他パッケージの統合テスト 15 件が同じように落ちるだけで、どの段が壊れたかを
切り分けられなかった。

`TestTextForDB` を新設した。入力はすべて実在する `cache_machiaza` の行を `normalizedExpr` と
同じ順で連結したもので、期待値はキャッシュが保存している `normalized_address`。
`NormalizeDashes` は規則が 2 本あるため U+2015 と U+30FC の両方を置いた。

`NormalizeSpaces` は両パイプラインに同じ位置で入っているが、どちらもテストが無かった。
キャッシュの `oaza_cho` と `koaza` に空白を含む行は 0 件で、DB 側は実在の行では動かせない。
守るべきは段の存在ではなく両パイプラインが一致することなので、
`TestSpaceCollapsingIsTheSameOnBothPipelines` で固定した。

段を 1 つずつ外して落ちるテストを数えると、次のようになる。

| 外した段 | 前 | 後 |
| :--- | --: | --: |
| `basicNormalizedSteps` の `NormalizeSpaces` | 0 | 2 |
| `dbSteps` の `NormalizeSpaces` | 0 | 1 |
| `dbSteps` の `NormalizeDashes` | 0 | 3 |
| `dbSteps` の他 6 段 | 各 15、すべて同一 | 各 16 以上、段ごとに別のテスト |
