### PR TITLE
ci: ワークフローのトリガーから v3-beta を外す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, v3-beta]
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main, v3-beta]
+    branches: [main]
   pull_request:
-    branches: [main, v3-beta]
+    branches: [main]
   schedule:
     - cron: '0 0 * * 1'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: docker
 
 on:
   push:
-    branches: [main, v3-beta]
+    branches: [main]
     paths: &docker_paths
       - 'abrg/**'
       - 'abrdb/**'


### PR DESCRIPTION
## 概要

`v3-beta` を `main` にリネームしたため、ワークフローのトリガーに残った `v3-beta` の指定を外す。

## 変更内容

`ci.yml` / `codeql.yml` / `docker.yml` の `branches` から `v3-beta` を削除する。存在しないブランチを指しており、いずれも発火しない。

## 影響

CI の発火条件は変わらない。`main` への push と `main` に向けた pull request で従来どおり動く。
